### PR TITLE
Change ARM Ubuntu platform to updated workflow label

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-22.04, windows-latest, ARM64]
+        platform: [macos-latest, ubuntu-22.04, windows-latest, ubuntu-22.04-arm]
         node-version: [18]
 
     runs-on: ${{ matrix.platform }}
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-*-dev libappindicator3-dev librsvg2-dev patchelf libsoup2.4-dev libjavascriptcoregtk-4.0-dev
 
       - name: Install dependencies (ARM only)
-        if: matrix.platform == 'ARM64'
+        if: matrix.platform == 'ubuntu-22.04-arm'
         run: |
           apt-get update
           apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev wget

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,7 +7,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        platform: [macos-latest, ubuntu-22.04, windows-latest, ARM64]
+        platform: [macos-latest, ubuntu-22.04, windows-latest, ubuntu-22.04-arm]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Install dependencies (ARM only)
-        if: matrix.platform == 'ARM64'
+        if: matrix.platform == 'ubuntu-22.04-arm'
         run: |
           apt-get update
           apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev
@@ -50,7 +50,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        platform: [macos-latest, ubuntu-22.04, windows-latest, ARM64]
+        platform: [macos-latest, ubuntu-22.04, windows-latest, ubuntu-22.04-arm]
         node-version: [18]
 
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
We have a ui-test and rust-test job that is configured to run on MacOS, Windows, Ubuntu 22.04, and "ARM64".

Looks like the "ARM64" release and testing job platform is not supported. These jobs just sit and never get picked up by a runner

Here's some example runs:
- [A run which worked properly](https://github.com/meshtastic/network-management-client/actions/runs/9240250152) and took 1m 4s for `ui-test` and 7m 43s for `rust-test`
  - Started 9 months ago
- [The subsequent run failed to run these jobs](https://github.com/meshtastic/network-management-client/actions/runs/12323992764)
  - Started 2 months ago
- [The latest run to fail](https://github.com/meshtastic/network-management-client/actions/runs/13040767772)
  - Started 1 week ago

I think this tag was probably just changed by GitHub, as it's still experimental.

# Solution

I can't find anything in the docs about an "ARM64 runner"

Looking at the [list of GitHub runners available to public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), I think we should change our tag to the Ubuntu 22 on ARM. This PR does so.