### PR TITLE
Speed up logo splash animation

### DIFF
--- a/src/components/SplashScreen/SplashScreen.tsx
+++ b/src/components/SplashScreen/SplashScreen.tsx
@@ -48,7 +48,7 @@ export const SplashScreen = ({ unmountSelf }: ISplashScreenProps) => {
 
     const fadeOutHandle = setTimeout(() => {
       setScreenActive(false);
-    }, 4500);
+    }, 2500);
 
     return () => {
       clearTimeout(fadeOutHandle);

--- a/src/components/SplashScreen/SplashScreenLogo.css
+++ b/src/components/SplashScreen/SplashScreenLogo.css
@@ -3,9 +3,9 @@
   stroke-dashoffset: 180;
 
   animation-name: dash-mountain;
-  animation-duration: 2000ms;
+  animation-duration: 1000ms;
   animation-timing-function: ease-in-out;
-  animation-delay: 1000ms;
+  animation-delay: 500ms;
   animation-fill-mode: forwards;
 }
 
@@ -14,9 +14,9 @@
   stroke-dashoffset: 100;
 
   animation-name: dash-mountain;
-  animation-duration: 1000ms;
+  animation-duration: 500ms;
   animation-timing-function: ease-out;
-  animation-delay: 2000ms;
+  animation-delay: 1000ms;
   animation-fill-mode: forwards;
 }
 
@@ -27,7 +27,7 @@
   animation-name: dash-plus;
   animation-duration: 300ms;
   animation-timing-function: ease-in-out;
-  animation-delay: 2900ms;
+  animation-delay: 1600ms;
   animation-fill-mode: forwards;
 }
 
@@ -38,7 +38,7 @@
   animation-name: dash-plus;
   animation-duration: 300ms;
   animation-timing-function: ease-in-out;
-  animation-delay: 3050ms;
+  animation-delay: 1900ms;
   animation-fill-mode: forwards;
 }
 


### PR DESCRIPTION
This PR speeds up the logo splash animation from taking 4.5 seconds down to 2.5 seconds.

I think this animation takes a bit too long, and makes me wonder if the animation is hiding something loading. As far as I can tell, it's not. Tauri has its own splash screen functionality, which appears as a white screen before this logo splash appears.

Since this animation doesn't hide anything, no reason not to make it snappier!

Before:

https://github.com/user-attachments/assets/d12e99a9-0953-4d2f-bdbf-c10e7ff58ce0

After

https://github.com/user-attachments/assets/465793c6-1bce-4ceb-8506-58e5a26bde7d
