### PR TITLE
Fix map symbols appearing on top of windows

### DIFF
--- a/src/components/Map/MapSelectedNodeMenu.tsx
+++ b/src/components/Map/MapSelectedNodeMenu.tsx
@@ -81,7 +81,7 @@ export const MapSelectedNodeMenu = () => {
   };
 
   return (
-    <div className="absolute top-24 right-9 bg-white dark:bg-gray-800 p-5 pl-4 rounded-lg drop-shadow-lg w-80">
+    <div className="absolute top-24 right-9 bg-white dark:bg-gray-800 p-5 pl-4 rounded-lg drop-shadow-lg w-80 z-[inherit]">
       <div className="flex justify-between">
         <h1 className="text-gray-600 dark:text-gray-400 text-2xl leading-5 font-semibold">
           {deviceName}

--- a/src/components/Map/MapView.css
+++ b/src/components/Map/MapView.css
@@ -126,3 +126,7 @@
     color: rgb(209 213 219 / var(--tw-text-opacity)) !important;
   }
 }
+
+#deckgl-overlay {
+  z-index: 10;
+}

--- a/src/components/Map/MapView.tsx
+++ b/src/components/Map/MapView.tsx
@@ -158,8 +158,10 @@ export const MapView = () => {
         className="relative w-full h-full z-0"
         onContextMenu={(e) => e.preventDefault()}
       >
-        {nodeHoverInfo && <MapNodeTooltip hoverInfo={nodeHoverInfo} />}
-        {edgeHoverInfo && <MapEdgeTooltip hoverInfo={edgeHoverInfo} />}
+        <div className="z-40">
+          {nodeHoverInfo && <MapNodeTooltip hoverInfo={nodeHoverInfo} />}
+          {edgeHoverInfo && <MapEdgeTooltip hoverInfo={edgeHoverInfo} />}
+        </div>
 
         {/* Map translation is a pain, assuming users will use translated map tiles https://maplibre.org/maplibre-gl-js/docs/examples/language-switch/ */}
         <Map
@@ -180,8 +182,9 @@ export const MapView = () => {
             <Marker
               latitude={lastRightClickLngLat.lat}
               longitude={lastRightClickLngLat.lng}
+              style={{ zIndex: 30 }}
             >
-              <div className="translate-y-1/2">
+              <div className="translate-y-1/2 z-30">
                 {/* https://www.kindacode.com/article/how-to-create-triangles-with-tailwind-css-4-examples/ */}
                 <div className="w-full">
                   <div className="mx-auto w-0 h-0 border-l-[6px] border-l-transparent border-b-[8px]  border-b-gray-200 dark:border-b-gray-800 border-r-[6px] border-r-transparent" />
@@ -245,19 +248,17 @@ export const MapView = () => {
             ))}
         </Map>
 
-        {/* Popups */}
-        {showInfoPane === "waypoint" ? (
-          <WaypointMenu
-            editWaypoint={(w) => {
-              setWaypointDialogOpen(true);
-              setEditingWaypoint(w);
-            }}
-          />
-        ) : null}
-
         <div className="z-20">
           <NodeSearchDock />
           <MapSelectedNodeMenu />
+          {showInfoPane === "waypoint" ? (
+            <WaypointMenu
+              editWaypoint={(w) => {
+                setWaypointDialogOpen(true);
+                setEditingWaypoint(w);
+              }}
+            />
+          ) : null}
         </div>
       </div>
 

--- a/src/components/Map/MapView.tsx
+++ b/src/components/Map/MapView.tsx
@@ -172,6 +172,7 @@ export const MapView = () => {
           initialViewState={viewState}
           onClick={handleClick}
           onContextMenu={handleContextMenu}
+          className="z-10"
         >
           <DeckGLOverlay pickingRadius={12} layers={layers} />
 
@@ -254,8 +255,10 @@ export const MapView = () => {
           />
         ) : null}
 
-        <NodeSearchDock />
-        <MapSelectedNodeMenu />
+        <div className="z-20">
+          <NodeSearchDock />
+          <MapSelectedNodeMenu />
+        </div>
       </div>
 
       {(lastRightClickLngLat || editingWaypoint) && (

--- a/src/components/Map/MapView.tsx
+++ b/src/components/Map/MapView.tsx
@@ -174,7 +174,6 @@ export const MapView = () => {
           initialViewState={viewState}
           onClick={handleClick}
           onContextMenu={handleContextMenu}
-          className="z-10"
         >
           <DeckGLOverlay pickingRadius={12} layers={layers} />
 
@@ -216,18 +215,6 @@ export const MapView = () => {
             </Marker>
           )}
 
-          {/* Controls at bottom right */}
-          <ScaleControl
-            maxWidth={144}
-            position="bottom-right"
-            unit="imperial"
-          />
-          <NavigationControl
-            position="bottom-right"
-            showCompass
-            visualizePitch
-          />
-
           {/* Visualize all waypoints */}
           {waypoints
             // Filter invalid locations (falsy lat or long, includes 0,0)
@@ -244,6 +231,7 @@ export const MapView = () => {
                     ),
                   )
                 }
+                style={{ zIndex: 10 }}
               />
             ))}
         </Map>

--- a/src/components/NodeSearch/NodeSearchDock.tsx
+++ b/src/components/NodeSearch/NodeSearchDock.tsx
@@ -146,7 +146,7 @@ export const NodeSearchDock = () => {
   };
 
   return (
-    <div className="absolute left-9 top-9 w-96 flex flex-col p-4 gap-4">
+    <div className="absolute left-9 top-9 w-96 flex flex-col p-4 gap-4 z-[inherit]">
       <div className="flex flex-row gap-4">
         <NodeSearchInput
           query={query}

--- a/src/components/Waypoints/MeshWaypoint.tsx
+++ b/src/components/Waypoints/MeshWaypoint.tsx
@@ -5,7 +5,7 @@ import { WaypointIcon } from "@components/Waypoints/WaypointIcon";
 
 // This component returns a marker for each individual waypoint. It is called from MapView.tsx
 export interface IMeshWaypointProps
-  extends Pick<MarkerProps, "draggable" | "onDragEnd"> {
+  extends Pick<MarkerProps, "draggable" | "onDragEnd" | "style"> {
   waypoint: app_device_NormalizedWaypoint;
   isSelected: boolean;
   onClick?: () => void;

--- a/src/components/Waypoints/WaypointMenu.tsx
+++ b/src/components/Waypoints/WaypointMenu.tsx
@@ -65,7 +65,7 @@ export const WaypointMenu = ({ editWaypoint }: IWaypointMenuProps) => {
     activeWaypoint;
 
   return (
-    <div className="absolute top-24 right-9 bg-white dark:bg-gray-800 p-6 rounded-lg drop-shadow-lg w-96">
+    <div className="absolute top-24 right-9 bg-white dark:bg-gray-800 p-6 rounded-lg drop-shadow-lg w-96 z-[inherit]">
       <button
         className="absolute top-6 right-6"
         type="button"


### PR DESCRIPTION
Resolves #457

The base map currently has a z-index of 0.

### Changes

This PR assigns the following new z-indexes for portions of the map:
- 0: base map (this already exists, see above)
- 10: DeckGL symbols (nodes) and waypoints
- 20: map windows (node list, selected node/waypoint)
- 30: popups (the right-click "add waypoint" menu)
- 40: mouse hover elements (node/edge hover text)

### Details

This is mostly done by wrapping the relevant elements in divs with `z-#` Tailwind classes. The react-map-gl `Marker` elements only take CSSProperties, and the DeckGL layer doesn't seem to be styleable from JSX, so those are styled accordingly.

### For Reviewers

Please let me know if I'm missing any elements. I don't have multiple nodes to test 