### PR TITLE
Add tsc to ui:check and fix tsc issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "ui:build": "tsc && vite build",
     "ui:lint": "biome lint src",
     "ui:format": "biome format --write src",
-    "ui:check": "biome check src",
-    "ui:check:ci": "biome ci src --config-path=.",
+    "ui:check": "tsc --noEmit && biome check src",
+    "ui:check:ci": "tsc --noEmit && biome ci src --config-path=.",
     "ui:test": "jest --passWithNoTests",
     "ui:preview": "vite preview"
   },

--- a/src/components/Map/CreateWaypointDialog.tsx
+++ b/src/components/Map/CreateWaypointDialog.tsx
@@ -11,7 +11,6 @@ import * as Popover from "@radix-ui/react-popover";
 import * as Select from "@radix-ui/react-select";
 import debounce from "lodash.debounce";
 import { Locate, Plus, X } from "lucide-react";
-import maplibregl from "maplibre-gl";
 import moment from "moment";
 import { ChangeEventHandler, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -23,7 +22,7 @@ import {
   NavigationControl,
   ScaleControl,
   useMap,
-} from "react-map-gl";
+} from "react-map-gl/maplibre";
 import { useDispatch, useSelector } from "react-redux";
 import { warn } from "tauri-plugin-log-api";
 
@@ -184,8 +183,8 @@ export const CreateWaypointDialog = ({
   const handlePositionUpdate = useMemo(
     () =>
       debounce<(e: MarkerDragEvent) => void>((e) => {
-        setWaypointPosition(e.lngLat);
-        flyToPosition(e.lngLat);
+        setWaypointPosition(e.lngLat as LngLat);
+        flyToPosition(e.lngLat as LngLat);
       }, 300),
     [flyToPosition],
   );
@@ -257,7 +256,6 @@ export const CreateWaypointDialog = ({
               }}
               id={MapIDs.CreateWaypointDialog}
               mapStyle={style}
-              mapLib={maplibregl}
               initialViewState={{
                 latitude: waypointPosition.lat,
                 longitude: waypointPosition.lng,

--- a/src/components/Map/MapView.tsx
+++ b/src/components/Map/MapView.tsx
@@ -17,7 +17,7 @@ import {
   ViewState,
   ViewStateChangeEvent,
   useControl,
-} from "react-map-gl";
+} from "react-map-gl/maplibre";
 import { useDispatch, useSelector } from "react-redux";
 import { useDebounce } from "react-use";
 

--- a/src/components/Messaging/TextMessageBubble.tsx
+++ b/src/components/Messaging/TextMessageBubble.tsx
@@ -1,7 +1,7 @@
 import { MapIcon } from "lucide-react";
 import maplibregl from "maplibre-gl";
 // biome-ignore lint/suspicious/noShadowRestrictedNames: Need named export
-import { Map, ScaleControl } from "react-map-gl";
+import { Map, ScaleControl } from "react-map-gl/maplibre";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
@@ -105,7 +105,6 @@ export const TextMessageBubble = ({
                   borderRadius: "0px 0px 8px 8px",
                 }}
                 id={getWaypointMapId(message.payload.data.id)}
-                mapLib={maplibregl}
                 mapStyle={style}
                 interactive={false}
                 initialViewState={{

--- a/src/components/NodeSearch/NodeSearchDock.tsx
+++ b/src/components/NodeSearch/NodeSearchDock.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons";
 import { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { useMap } from "react-map-gl";
+import { useMap } from "react-map-gl/maplibre";
 import { useDispatch, useSelector } from "react-redux";
 
 import type {

--- a/src/components/Waypoints/MeshWaypoint.tsx
+++ b/src/components/Waypoints/MeshWaypoint.tsx
@@ -1,4 +1,4 @@
-import { Marker, MarkerProps } from "react-map-gl";
+import { Marker, MarkerProps } from "react-map-gl/maplibre";
 
 import type { app_device_NormalizedWaypoint } from "@bindings/index";
 import { WaypointIcon } from "@components/Waypoints/WaypointIcon";

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,4 @@
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore, MiddlewareArray } from "@reduxjs/toolkit";
 import { logger } from "redux-logger";
 
 import { appConfigReducer } from "@features/appConfig/slice";
@@ -24,7 +24,9 @@ export const store = configureStore({
     ui: uiReducer,
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({ thunk: false }).concat(middleware),
+    getDefaultMiddleware({ thunk: false }).concat(
+      middleware as MiddlewareArray<[]>,
+    ),
   devTools: true,
 });
 

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -10,7 +10,7 @@ export const formatLocation = (location: number): string =>
 export const getFlyToConfig = (target: {
   lng: number;
   lat: number;
-}): mapboxgl.FlyToOptions => ({
+}): maplibregl.FlyToOptions => ({
   center: [target.lng, target.lat],
   bearing: 0,
   pitch: 0,


### PR DESCRIPTION
Currently, this repo fails the `tsc` check. We currently don't run this in CI except on build, so we haven't caught it until now.

This PR:
- Updates the `ui:check` and `ui:check:ci` scripts to run tsc along with the existing biome.
- Fixes current `tsc` errors
  - This is mostly specifying some types in the map library to use MapLibre GL JS types.