### PR TITLE
Fix Biome errors from refactored logo

### DIFF
--- a/src/components/Sidebar/SidebarLogo.tsx
+++ b/src/components/Sidebar/SidebarLogo.tsx
@@ -1,7 +1,5 @@
 import { useTranslation } from "react-i18next";
 
-import MeshLogoDark from "@app/assets/Mesh_Logo_Dynamic.svg";
-import MeshLogoLight from "@app/assets/Mesh_Logo_Dynamic.svg";
 import { MeshtasticLogo } from "@app/assets/Meshtastic";
 
 import { useIsDarkMode } from "@utils/hooks";

--- a/src/components/pages/ConnectPage.tsx
+++ b/src/components/pages/ConnectPage.tsx
@@ -4,8 +4,6 @@ import { FormEventHandler, useCallback, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
-import MeshLogoDark from "@app/assets/Mesh_Logo_Dark.svg";
-import MeshLogoLight from "@app/assets/Mesh_Logo_Light.svg";
 import Hero_Image from "@app/assets/onboard_hero_image.jpg";
 
 import { ConnectTab } from "@components/connection/ConnectTab";


### PR DESCRIPTION
A few linter warnings were introduced in #482. They were Biome's `lint/nursery/noUnusedImports`

This fixes those. You should be able to see the linter CI job run without any output now.