### PR TITLE
ci: Add Devcontainer to project

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/devcontainers/typescript-node:1.1-22
+
+# Install Xvfb
+RUN apt-get update 
+RUN apt-get install -y \
+    xvfb \
+    libpango1.0-dev \
+    libgtk-3-dev \
+    libwebkit2gtk-4.0-dev \
+    libappindicator3-dev \
+    librsvg2-dev
+
+# Set up Xvfb
+ENV DISPLAY=:99
+RUN Xvfb :99 -screen 0 1024x768x16 &

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,15 +1,12 @@
 FROM mcr.microsoft.com/devcontainers/typescript-node:1.1-22
 
-# Install Xvfb
-RUN apt-get update 
-RUN apt-get install -y \
-    xvfb \
-    libpango1.0-dev \
+RUN sudo apt update
+RUN sudo apt install -y libwebkit2gtk-4.0-dev \
+    build-essential \
+    curl \
+    wget \
+    file \
+    libssl-dev \
     libgtk-3-dev \
-    libwebkit2gtk-4.0-dev \
-    libappindicator3-dev \
+    libayatana-appindicator3-dev \
     librsvg2-dev
-
-# Set up Xvfb
-ENV DISPLAY=:99
-RUN Xvfb :99 -screen 0 1024x768x16 &

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+			"dockerfile": "Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/rust:1": {
+			"version": "latest",
+			"profile": "complete",
+			"targets": "aarch64-unknown-linux-gnu"
+		}
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"tauri-apps.tauri-vscode",
+				"biomejs.biome",
+				"rust-lang.rust-analyzer",
+				"eamodio.gitlens"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		5173
+	],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "git submodule update --init && pnpm i"
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+
+	// Set environment variables for the container.
+	// "containerEnv": {}
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.sln
 *.sw?
 node_modules
+
+.pnpm-store/

--- a/README.md
+++ b/README.md
@@ -166,6 +166,33 @@ We are currently working to add support for the [Storybook](https://storybook.js
 
 > **Note:** On Linux, your user may not have permission to access a given serial port. If this happens, you will likely need to add your user to the group that controls the serial port you want to access. You can find the group that controls a serial port via the `ls -ld PATH_TO_PORT_HERE` command. You can add your user to this group via the `usermod -a -G GROUP_NAME_HERE $USER` command.
 
+## :whale: Using the Devcontainer
+
+This project includes a devcontainer configuration for Visual Studio Code, which allows you to develop inside a containerized environment. This ensures that all developers have a consistent development environment, regardless of their local machine setup.
+
+### Prerequisites
+
+To use the devcontainer, you need to have the following installed:
+
+- [Docker](https://www.docker.com/get-started)
+- [Visual Studio Code](https://code.visualstudio.com/)
+- [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) for Visual Studio Code
+
+### Setup
+
+1. Open the project in Visual Studio Code.
+2. Press `F1` to open the command palette, and type `Remote-Containers: Open Folder in Container...`.
+3. Select the project folder. Visual Studio Code will build the devcontainer and open the project inside it.
+4. The `postCreateCommand` specified in the `devcontainer.json` will automatically run `git submodule update --init && pnpm i` to set up the project.
+
+### Development
+
+Once the devcontainer is set up, you can use the same development commands as described in the [Development Commands](#development-commands) section. The devcontainer includes all necessary dependencies and tools for developing and testing the project.
+
+> **Note:** If you encounter any issues with permissions, you may need to adjust the user permissions inside the container. Refer to the [Tauri documentation](https://tauri.app/v1/guides/getting-started/prerequisites/) for more details.
+
+By using the devcontainer, you ensure that your development environment is consistent with the rest of the team, reducing the likelihood of environment-specific issues.
+
 ## :heart: Contributing
 
 As we are still very early in development, we don't yet have a standardized framework for accepting contributions. This being said, we are very open to suggestions and/or code changes! If you're interested in contributing to this repository, we would ask that you first check our issue board to ensure your work isn't duplicating the work of others. Then, please make an issue on our board so we know what you're interested in working on. If you have any questions about the project, we would love to hear from you!


### PR DESCRIPTION
Adding devcontainers makes keeping versions constant easier, and makes the development lifecycle much easier as well.