### PR TITLE
Specify channel vs direct messaging in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ This project is still in early stages of development, but here's a rough roadmap
   - [x] On-map waypoint tooltip
 - [ ] :globe_with_meridians: Web client parity (UI)
   - [x] Map node view
-  - [x] Text messaging
+  - [ ] Messaging
+    - [x] Channel messaging
+    - [ ] Direct messaging
   - [ ] Channel import/export via QR code
   - [x] Configuration
     - [x] Device configuration


### PR DESCRIPTION
The README roadmap doesn't differentiate between messaging in a channel vs DMs. This should be specified to avoid being misleading.

This was mentioned in #463