### PR TITLE
UI: Reverse collapse sidebar button logic

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -166,7 +166,7 @@ export const Sidebar = () => {
         <hr className="border-gray-100 dark:border-gray-700" />
 
         <SidebarIcon
-          name={isSidebarExpanded ? t("sidebar.expand") : t("sidebar.collapse")}
+          name={isSidebarExpanded ? t("sidebar.collapse") : t("sidebar.expand")}
           isActive={false}
           isSidebarExpanded={isSidebarExpanded}
           onClick={() => setSidebarExpanded(!isSidebarExpanded)}


### PR DESCRIPTION
Reverses the collapse sidebar button label logic to show "Expand Sidebar" when collapsed, and "Collapse Sidebar" when expanded.

![image](https://github.com/user-attachments/assets/f7b57ad1-dff0-468f-a6ff-e7ccea76c5b9)


fixes: #495
