### PR TITLE
fix: disable Specta typescript gen and pin logging level

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -26,11 +26,7 @@ fn export_ts_types(file_path: &str) -> Result<(), TsExportError> {
     ts_with_cfg(file_path, &ts_export_config)
 }
 
-#[cfg(debug_assertions)]
 const LOG_LEVEL: LevelFilter = LevelFilter::Debug;
-
-#[cfg(not(debug_assertions))]
-const LOG_LEVEL: LevelFilter = LevelFilter::Trace;
 
 fn main() {
     tauri::Builder::default()
@@ -43,10 +39,9 @@ fn main() {
         )
         .plugin(tauri_plugin_store::Builder::default().build())
         .setup(|app| {
-            info!("Building TS types from Rust");
-
-            #[cfg(debug_assertions)]
-            export_ts_types("../src/bindings/index.ts")?;
+            // info!("Building TS types from Rust");
+            // #[cfg(debug_assertions)]
+            // export_ts_types("../src/bindings/index.ts")?;
 
             let initial_mesh_devices_state = state::mesh_devices::MeshDevicesState::new();
             let initial_radio_connections_state =


### PR DESCRIPTION
This PR should fix the app's production build.

A couple issues addressed:
- Specta type generation is broken, so this disables it. This means the `src/bindings/index.ts` will not update on build. Previously this would be replaced with an empty file, which would then break the types used in the web app.
- Pins the logging level to "DEBUG". For some reason, in the production build was set to "TRACE" and this would make the app stall on startup.

Both of these issues should be addressed in another story.

This fixes local builds on my Mac using `pnpm tauri build` and our target `pnpm rust:build`. Not yet tested this on Linux builds