### PR TITLE
fix: use ad-hoc signing for MacOS builds

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -66,7 +66,7 @@
         "exceptionDomain": "",
         "frameworks": [],
         "providerShortName": null,
-        "signingIdentity": null
+        "signingIdentity": "-"
       },
       "resources": [],
       "shortDescription": "",


### PR DESCRIPTION
This fixes the "This app is damaged" message showing up on MacOS preventing users from opening the app without removing the quarantine manually.

MacOS on ARM requires apps to be signed, but you can do what's called an "ad-hoc" signature that has no signer identity from Apple. Instead, you pass the identity `-`.

This does not eliminate [the need to allow the app in your Privacy & Security settings](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac). To eliminate this, we will need to [set up codesigning for Mac builds](https://tauri.app/distribute/sign/macos/).

Issue from Tauri tracking this:
https://github.com/tauri-apps/tauri/issues/8763