### PR TITLE
Rename tag to 'v___'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
+          tagName: v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
           releaseName: "MNMC v__VERSION__"
           releaseBody: "See release assets to download this version and install."
           releaseDraft: true


### PR DESCRIPTION
Renames the default release tag from GitHub Actions to just "vX.Y.Z" instead of "app-vX.Y.Z"