### PR TITLE
Update minimum supported Rust version

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 repository = ""
 default-run = "app"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.76"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
In preparation for meshtastic crate update to 1.76: https://github.com/meshtastic/rust/pull/48