### PR TITLE
Bluetooth Support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2087,15 +2087,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,20 +2868,21 @@ dependencies = [
 [[package]]
 name = "meshtastic"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2c3275a1261e96e1321d3cf8eaed1b8797ba49d76aa8a7be47900d3efa6617"
+source = "git+https://github.com/meshtastic/rust.git?rev=6057294aa6cfa979033299f7f02cfe6ceafddeda#6057294aa6cfa979033299f7f02cfe6ceafddeda"
 dependencies = [
+ "bluez-async",
  "btleplug",
+ "futures",
  "futures-util",
  "log",
  "prost",
  "prost-build",
  "protoc-bin-vendored",
- "rand 0.8.5",
+ "rand 0.9.1",
  "serde",
  "serde_json",
- "specta 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
+ "specta 1.0.3 (git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d)",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-serial",
  "tokio-util",
@@ -3838,12 +3830,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3915,9 +3907,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3925,44 +3917,42 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.9"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "bytes",
  "heck 0.4.1",
  "itertools 0.10.5",
- "lazy_static",
  "log",
  "multimap",
+ "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.101",
  "tempfile",
- "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
  "prost",
 ]
@@ -5074,17 +5064,17 @@ dependencies = [
 [[package]]
 name = "specta"
 version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95aa33f3135e656964f468db8369ac8e0b77ac957fe8cf335960202d68966d3b"
+source = "git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d#6a8731d168376e28e163dd9cd328055b11d1af82"
 dependencies = [
  "chrono",
+ "ctor 0.1.26",
  "document-features",
  "indoc",
  "once_cell",
  "paste",
  "serde",
  "serde_json",
- "specta-macros 1.0.5",
+ "specta-macros 1.0.3 (git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d)",
  "thiserror 1.0.69",
 ]
 
@@ -5101,14 +5091,14 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
- "specta-macros 1.0.3",
+ "specta-macros 1.0.3 (git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d168376e28e163dd9cd328055b11d1af82)",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "specta-macros"
 version = "1.0.3"
-source = "git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d168376e28e163dd9cd328055b11d1af82#6a8731d168376e28e163dd9cd328055b11d1af82"
+source = "git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d#6a8731d168376e28e163dd9cd328055b11d1af82"
 dependencies = [
  "Inflector",
  "itertools 0.10.5",
@@ -5120,9 +5110,8 @@ dependencies = [
 
 [[package]]
 name = "specta-macros"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4605306321c356e03873b8ee71d7592a5e7c508add325c3ed0677c16fdf1bcfb"
+version = "1.0.3"
+source = "git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d168376e28e163dd9cd328055b11d1af82#6a8731d168376e28e163dd9cd328055b11d1af82"
 dependencies = [
  "Inflector",
  "itertools 0.10.5",
@@ -6722,18 +6711,6 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
 
 [[package]]
 name = "wide"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -151,6 +151,7 @@ name = "app"
 version = "0.3.1"
 dependencies = [
  "async-trait",
+ "btleplug",
  "bytes",
  "chrono",
  "defaultdict",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ tauri-plugin-store = "2"
 tokio-serial = "5.4.4"
 tauri-plugin-log = { features = ["colored"] , version = "2" }
 chrono = { version = "0.4.34", features = ["serde"] }
-meshtastic = { version = "0.1.6", features = ["ts-gen"] }
+meshtastic = { git = "https://github.com/meshtastic/rust.git", rev = "6057294aa6cfa979033299f7f02cfe6ceafddeda", features = ["ts-gen", "bluetooth-le"] }
 specta = { git = "https://github.com/ajmcquilkin/specta.git", rev = "6a8731d168376e28e163dd9cd328055b11d1af82", version = "1.0.3", features = ["chrono"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ tauri-plugin-notification = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-http = "2"
 tauri-plugin-cli = "2"
+btleplug = "0.11.8"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/device/mod.rs
+++ b/src-tauri/src/device/mod.rs
@@ -180,9 +180,9 @@ pub struct NormalizedPosition {
 impl From<protobufs::Position> for NormalizedPosition {
     fn from(position: protobufs::Position) -> Self {
         Self {
-            latitude: normalize_location_field(position.latitude_i),
-            longitude: normalize_location_field(position.longitude_i),
-            altitude: position.altitude,
+            latitude: normalize_location_field(position.latitude_i.unwrap_or_default()),
+            longitude: normalize_location_field(position.longitude_i.unwrap_or_default()),
+            altitude: position.altitude.unwrap_or_default(),
             time: position.time,
             location_source: protobufs::position::LocSource::from_i32(position.location_source)
                 .expect("Could not convert i32 to LocSource"),
@@ -190,14 +190,14 @@ impl From<protobufs::Position> for NormalizedPosition {
                 .expect("Could not convert i32 to AltSource"),
             timestamp: position.timestamp,
             timestamp_millis_adjust: position.timestamp_millis_adjust,
-            altitude_hae: position.altitude_hae,
-            altitude_geoidal_separation: position.altitude_geoidal_separation,
+            altitude_hae: position.altitude_hae.unwrap_or_default(),
+            altitude_geoidal_separation: position.altitude_geoidal_separation.unwrap_or_default(),
             pdop: position.pdop,
             hdop: position.hdop,
             vdop: position.vdop,
             gps_accuracy: position.gps_accuracy,
-            ground_speed: position.ground_speed,
-            ground_track: position.ground_track,
+            ground_speed: position.ground_speed.unwrap_or_default(),
+            ground_track: position.ground_track.unwrap_or_default(),
             fix_quality: position.fix_quality,
             fix_type: position.fix_type,
             sats_in_view: position.sats_in_view,
@@ -283,8 +283,8 @@ impl From<protobufs::Waypoint> for NormalizedWaypoint {
         Self {
             id: waypoint.id,
             // Converting to f64 first to cover entire i32 range
-            latitude: normalize_location_field(waypoint.latitude_i),
-            longitude: normalize_location_field(waypoint.longitude_i),
+            latitude: normalize_location_field(waypoint.latitude_i.unwrap_or_default()),
+            longitude: normalize_location_field(waypoint.longitude_i.unwrap_or_default()),
             expire: waypoint.expire,
             locked_to: waypoint.locked_to,
             name: waypoint.name,
@@ -299,8 +299,8 @@ impl Into<protobufs::Waypoint> for NormalizedWaypoint {
         protobufs::Waypoint {
             id: self.id,
             // Converting to f64 first to cover entire i32 range
-            latitude_i: convert_location_field_to_protos(self.latitude),
-            longitude_i: convert_location_field_to_protos(self.longitude),
+            latitude_i: Some(convert_location_field_to_protos(self.latitude)),
+            longitude_i: Some(convert_location_field_to_protos(self.longitude)),
             expire: self.expire,
             locked_to: self.locked_to,
             name: self.name,

--- a/src-tauri/src/device/state.rs
+++ b/src-tauri/src/device/state.rs
@@ -58,6 +58,16 @@ impl MeshDevice {
                     trace!("Updated own bluetooth config: {:?}", bluetooth);
                     self.config.bluetooth = Some(bluetooth);
                 }
+                protobufs::config::PayloadVariant::Security(security) => {
+                    trace!("Updated own security config: {:?}", security);
+                    self.config.security = Some(security);
+                }
+                protobufs::config::PayloadVariant::Sessionkey(session_key) => {
+                    trace!("Received session key config: {:?}", session_key);
+                }
+                protobufs::config::PayloadVariant::DeviceUi(device_ui) => {
+                    trace!("Received Device UI config: {:?}", device_ui);
+                }
             }
         }
     }
@@ -165,6 +175,14 @@ impl MeshDevice {
                     protobufs::telemetry::Variant::PowerMetrics(power_metrics) => {
                         debug!("Received power metrics, not handling");
                         trace!("{:?}", power_metrics);
+                    }
+                    protobufs::telemetry::Variant::LocalStats(local_stats) => {
+                        debug!("Received local stats, not handling");
+                        trace!("{:?}", local_stats);
+                    }
+                    protobufs::telemetry::Variant::HealthMetrics(health_metrics) => {
+                        debug!("Received health metrics, not handling");
+                        trace!("{:?}", health_metrics);
                     }
                 }
             }

--- a/src-tauri/src/ipc/commands/connections.rs
+++ b/src-tauri/src/ipc/commands/connections.rs
@@ -35,6 +35,16 @@ pub async fn request_autoconnect_port(
     Ok(autoconnect_port)
 }
 
+// Tauri command
+#[tauri::command]
+pub fn get_all_bluetooth() -> Result<Vec<String>, CommandError> {
+    debug!("Called get_all_bluetooth command");
+
+    let devices = vec!["mxie_2128".to_string(), "woaha".to_string(), "Freak out!".to_string()];
+
+    Ok(devices)
+}
+
 #[tauri::command]
 pub fn get_all_serial_ports() -> Result<Vec<String>, CommandError> {
     debug!("Called get_all_serial_ports command");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             ipc::commands::connections::request_autoconnect_port,
             ipc::commands::connections::get_all_serial_ports,
+            ipc::commands::connections::connect_to_bluetooth,
             ipc::commands::connections::connect_to_serial_port,
             ipc::commands::connections::connect_to_tcp_port,
             ipc::commands::connections::drop_device_connection,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,6 +78,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             ipc::commands::connections::request_autoconnect_port,
+            ipc::commands::connections::get_all_bluetooth,
             ipc::commands::connections::get_all_serial_ports,
             ipc::commands::connections::connect_to_bluetooth,
             ipc::commands::connections::connect_to_serial_port,

--- a/src-tauri/src/packet_api/router.rs
+++ b/src-tauri/src/packet_api/router.rs
@@ -79,6 +79,15 @@ impl<R: tauri::Runtime> PacketRouter<(), DeviceUpdateError> for MeshPacketApi<R>
                     "mqtt client proxy message".into(),
                 ));
             }
+            protobufs::from_radio::PayloadVariant::FileInfo(_) => {
+                return Err(DeviceUpdateError::RadioMessageNotSupported("file info".into()));
+            }
+            protobufs::from_radio::PayloadVariant::ClientNotification(_) => {
+                return Err(DeviceUpdateError::RadioMessageNotSupported("client notification".into()));
+            }
+            protobufs::from_radio::PayloadVariant::DeviceuiConfig(_) => {
+                return Err(DeviceUpdateError::RadioMessageNotSupported("device ui config".into()));
+            }
         };
 
         Ok(())
@@ -190,6 +199,12 @@ impl<R: tauri::Runtime> PacketRouter<(), DeviceUpdateError> for MeshPacketApi<R>
                 }
                 protobufs::PortNum::MapReportApp => {
                     return Err(DeviceUpdateError::PacketNotSupported("mapreport".into()));
+                }
+                protobufs::PortNum::AlertApp => {
+                    return Err(DeviceUpdateError::PacketNotSupported("alert".into()));
+                }
+                protobufs::PortNum::PowerstressApp => {
+                    return Err(DeviceUpdateError::PacketNotSupported("powerstress".into()));
                 }
             },
             protobufs::mesh_packet::PayloadVariant::Encrypted(_e) => {

--- a/src/api/connection.ts
+++ b/src/api/connection.ts
@@ -63,3 +63,13 @@ export const dropAllDeviceConnections = async () => {
 
   return response;
 };
+
+export const connectToBluetooth = async (
+  bluetoothName: string,
+) => {
+  const response = (await invoke("connect_to_bluetooth", {
+    bluetoothName,
+  })) as undefined;
+
+  return response;
+};

--- a/src/api/connection.ts
+++ b/src/api/connection.ts
@@ -20,6 +20,12 @@ export const requestAutoConnectPort = async () => {
   return response;
 };
 
+export const getAllBluetooth = async () => {
+  const response = (await invoke("get_all_bluetooth")) as string[];
+
+  return response;
+};
+
 export const getAllSerialPorts = async () => {
   const response = (await invoke("get_all_serial_ports")) as string[];
 

--- a/src/components/connection/BluetoothConnectPane.tsx
+++ b/src/components/connection/BluetoothConnectPane.tsx
@@ -13,14 +13,6 @@ export interface ISerialConnectPaneProps {
   activePort: string;
   activePortState: RequestStatus;
   handlePortSelected: (portName: string) => void;
-  isAdvancedOpen: boolean;
-  setAdvancedOpen: (isAdvancedOpen: boolean) => void;
-  baudRate: number;
-  setBaudRate: (baudRate: number) => void;
-  dtr: boolean;
-  setDtr: (dtr: boolean) => void;
-  rts: boolean;
-  setRts: (rts: boolean) => void;
   refreshPorts: () => void;
 }
 
@@ -30,37 +22,15 @@ export const BluetoothConnectPane = ({
   activePortState,
   handlePortSelected,
   refreshPorts,
-  isAdvancedOpen,
-  setAdvancedOpen,
-  baudRate,
-  setBaudRate,
-  dtr,
-  setDtr,
-  rts,
-  setRts,
 }: ISerialConnectPaneProps) => {
   const { t } = useTranslation();
 
   return (
-    <Collapsible.Root open={isAdvancedOpen} onOpenChange={setAdvancedOpen}>
+    <Collapsible.Root open={true}>
       <div className="flex flex-col mt-4">
         <div className="flex flex-col gap-4">
-          {availableSerialPorts?.length ? (
-            availableSerialPorts.map((portName) => (
-              <SerialPortOption
-                key={portName}
-                name={portName}
-                connectionState={
-                  activePort === portName ? activePortState : { status: "IDLE" }
-                }
-                onClick={handlePortSelected}
-              />
-            ))
-          ) : (
-            <p className="text-base leading-6 font-normal text-gray-500 dark:text-gray-400 pl-40 pr-40 text-center">
-              {t("connectPage.tabs.serial.empty")}
-            </p>
-          )}
+          <button onClick={() => {handlePortSelected(activePort)}}>Connect!</button>
+          {activePortState.status}
         </div>
       </div>
 
@@ -74,45 +44,6 @@ export const BluetoothConnectPane = ({
           {t("connectPage.tabs.serial.refresh")}
         </p>
       </button>
-
-      <Collapsible.Trigger asChild>
-        <button
-          type="button"
-          className="flex flex-row align-middle justify-between w-full mt-5 mb-2"
-        >
-          <p className="my-auto text-base font-normal text-gray-500 dark:text-gray-400">
-            {t("connectPage.tabs.serial.advancedTitle")}
-          </p>
-          <span className="my-auto text-gray-500 dark:text-gray-400">
-            {isAdvancedOpen ? <Cross2Icon /> : <RowSpacingIcon />}
-          </span>
-        </button>
-      </Collapsible.Trigger>
-
-      <Collapsible.Content>
-        <div className="flex flex-col gap-4">
-          <ConnectionInput
-            type="number"
-            placeholder={t("connectPage.tabs.serial.baudTitle")}
-            value={baudRate}
-            onChange={(e) => setBaudRate(parseInt(e.target.value))}
-          />
-
-          <div className="flex flex-row justify-between">
-            <p className="text-base font-normal text-gray-500 dark:text-gray-400">
-              {t("connectPage.tabs.serial.dtrTitle")}
-            </p>
-            <ConnectionSwitch checked={dtr} setChecked={setDtr} />
-          </div>
-
-          <div className="flex flex-row justify-between">
-            <p className="text-base font-normal text-gray-500 dark:text-gray-400">
-              {t("connectPage.tabs.serial.rtsTitle")}
-            </p>
-            <ConnectionSwitch checked={rts} setChecked={setRts} />
-          </div>
-        </div>
-      </Collapsible.Content>
     </Collapsible.Root>
   );
 };

--- a/src/components/connection/BluetoothConnectPane.tsx
+++ b/src/components/connection/BluetoothConnectPane.tsx
@@ -1,0 +1,118 @@
+import { ArrowPathIcon } from "@heroicons/react/24/outline";
+import * as Collapsible from "@radix-ui/react-collapsible";
+import { Cross2Icon, RowSpacingIcon } from "@radix-ui/react-icons";
+import { useTranslation } from "react-i18next";
+
+import { ConnectionInput } from "@components/connection/ConnectionInput";
+import { ConnectionSwitch } from "@components/connection/ConnectionSwitch";
+import { SerialPortOption } from "@components/connection/SerialPortOption";
+import type { RequestStatus } from "@features/requests/slice";
+
+export interface ISerialConnectPaneProps {
+  availableSerialPorts: string[] | null;
+  activePort: string;
+  activePortState: RequestStatus;
+  handlePortSelected: (portName: string) => void;
+  isAdvancedOpen: boolean;
+  setAdvancedOpen: (isAdvancedOpen: boolean) => void;
+  baudRate: number;
+  setBaudRate: (baudRate: number) => void;
+  dtr: boolean;
+  setDtr: (dtr: boolean) => void;
+  rts: boolean;
+  setRts: (rts: boolean) => void;
+  refreshPorts: () => void;
+}
+
+export const BluetoothConnectPane = ({
+  availableSerialPorts,
+  activePort,
+  activePortState,
+  handlePortSelected,
+  refreshPorts,
+  isAdvancedOpen,
+  setAdvancedOpen,
+  baudRate,
+  setBaudRate,
+  dtr,
+  setDtr,
+  rts,
+  setRts,
+}: ISerialConnectPaneProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Collapsible.Root open={isAdvancedOpen} onOpenChange={setAdvancedOpen}>
+      <div className="flex flex-col mt-4">
+        <div className="flex flex-col gap-4">
+          {availableSerialPorts?.length ? (
+            availableSerialPorts.map((portName) => (
+              <SerialPortOption
+                key={portName}
+                name={portName}
+                connectionState={
+                  activePort === portName ? activePortState : { status: "IDLE" }
+                }
+                onClick={handlePortSelected}
+              />
+            ))
+          ) : (
+            <p className="text-base leading-6 font-normal text-gray-500 dark:text-gray-400 pl-40 pr-40 text-center">
+              {t("connectPage.tabs.serial.empty")}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="flex flex-row justify-center align-middle mx-auto gap-4 mt-5"
+        onClick={() => refreshPorts()}
+      >
+        <ArrowPathIcon className="text-gray-400 dark:text-gray-300 w-6 h-6 hover:cursor-pointer" />
+        <p className="my-auto text-gray-500 dark:text-gray-400">
+          {t("connectPage.tabs.serial.refresh")}
+        </p>
+      </button>
+
+      <Collapsible.Trigger asChild>
+        <button
+          type="button"
+          className="flex flex-row align-middle justify-between w-full mt-5 mb-2"
+        >
+          <p className="my-auto text-base font-normal text-gray-500 dark:text-gray-400">
+            {t("connectPage.tabs.serial.advancedTitle")}
+          </p>
+          <span className="my-auto text-gray-500 dark:text-gray-400">
+            {isAdvancedOpen ? <Cross2Icon /> : <RowSpacingIcon />}
+          </span>
+        </button>
+      </Collapsible.Trigger>
+
+      <Collapsible.Content>
+        <div className="flex flex-col gap-4">
+          <ConnectionInput
+            type="number"
+            placeholder={t("connectPage.tabs.serial.baudTitle")}
+            value={baudRate}
+            onChange={(e) => setBaudRate(parseInt(e.target.value))}
+          />
+
+          <div className="flex flex-row justify-between">
+            <p className="text-base font-normal text-gray-500 dark:text-gray-400">
+              {t("connectPage.tabs.serial.dtrTitle")}
+            </p>
+            <ConnectionSwitch checked={dtr} setChecked={setDtr} />
+          </div>
+
+          <div className="flex flex-row justify-between">
+            <p className="text-base font-normal text-gray-500 dark:text-gray-400">
+              {t("connectPage.tabs.serial.rtsTitle")}
+            </p>
+            <ConnectionSwitch checked={rts} setChecked={setRts} />
+          </div>
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+};

--- a/src/components/connection/BluetoothConnectPane.tsx
+++ b/src/components/connection/BluetoothConnectPane.tsx
@@ -7,9 +7,10 @@ import { ConnectionInput } from "@components/connection/ConnectionInput";
 import { ConnectionSwitch } from "@components/connection/ConnectionSwitch";
 import { SerialPortOption } from "@components/connection/SerialPortOption";
 import type { RequestStatus } from "@features/requests/slice";
+import { BluetoothDeviceOption } from "@components/connection/BluetoothDeviceOption";
 
 export interface ISerialConnectPaneProps {
-  availableSerialPorts: string[] | null;
+  availableBluetoothDevices: string[] | null;
   activePort: string;
   activePortState: RequestStatus;
   handlePortSelected: (portName: string) => void;
@@ -17,7 +18,7 @@ export interface ISerialConnectPaneProps {
 }
 
 export const BluetoothConnectPane = ({
-  availableSerialPorts,
+  availableBluetoothDevices,
   activePort,
   activePortState,
   handlePortSelected,
@@ -29,8 +30,23 @@ export const BluetoothConnectPane = ({
     <Collapsible.Root open={true}>
       <div className="flex flex-col mt-4">
         <div className="flex flex-col gap-4">
-          <button onClick={() => {handlePortSelected(activePort)}}>Connect!</button>
-          {activePortState.status}
+
+          {availableBluetoothDevices?.length ? (
+            availableBluetoothDevices.map((portName) => (
+              <BluetoothDeviceOption
+                key={portName}
+                name={portName}
+                connectionState={
+                  activePort === portName ? activePortState : { status: "IDLE" }
+                }
+                onClick={handlePortSelected}
+              />
+            ))
+          ) : (
+            <p className="text-base leading-6 font-normal text-gray-500 dark:text-gray-400 pl-40 pr-40 text-center">
+              {t("connectPage.tabs.serial.empty")}
+            </p>
+          )}
         </div>
       </div>
 

--- a/src/components/connection/BluetoothDeviceOption.tsx
+++ b/src/components/connection/BluetoothDeviceOption.tsx
@@ -1,0 +1,94 @@
+import {
+  CheckCircleIcon,
+  EllipsisHorizontalCircleIcon,
+  XCircleIcon,
+} from "@heroicons/react/24/outline";
+import { Bluetooth } from "lucide-react";
+import { Trans } from "react-i18next";
+
+import type { RequestStatus } from "@features/requests/slice";
+
+export interface ISerialPortOptions {
+  name: string;
+  connectionState: RequestStatus;
+  onClick: (portName: string) => void;
+}
+
+export const BluetoothDeviceOption = ({
+  name,
+  connectionState,
+  onClick,
+}: ISerialPortOptions) => {
+  switch (connectionState.status) {
+    case "PENDING":
+      return (
+        <div className="flex justify-center select-none">
+          <div className="flex flex-1 justify-left border rounded-lg border-gray-500 dark:border-gray-200 pl-4 pt-5 pb-5 pr-4 w-6/12 hover:cursor-wait bg-white dark:bg-gray-800">
+            <EllipsisHorizontalCircleIcon className="text-gray-500 dark:text-gray-300 w-6 h-6" />
+            <h1 className="ml-4 text-base leading-6 font-normal text-gray-600 dark:text-gray-400 mt-0.5">
+              <Trans
+                i18nKey="connectPage.tabs.bluetooth.portOption"
+                values={{ deviceName: name }}
+              />
+            </h1>
+          </div>
+        </div>
+      );
+
+    case "SUCCESSFUL":
+      return (
+        <div className="flex justify-center select-none">
+          <div className="flex flex-1 justify-left border rounded-lg border-green-500 dark:border-green-400 bg-green-50 dark:bg-green-900 pl-4 pt-5 pb-5 pr-4 w-6/12">
+            <CheckCircleIcon className="text-green-600 dark:text-green-500 w-6 h-6" />
+            <h1 className="ml-4 text-base leading-6 font-normal text-green-600 dark:text-green-500 mt-0.5">
+              <Trans
+                i18nKey="connectPage.tabs.bluetooth.portOption"
+                values={{ deviceName: name }}
+              />
+            </h1>
+          </div>
+        </div>
+      );
+
+    case "FAILED":
+      return (
+        <div className="flex justify-center select-none">
+          <div className="flex-1 border rounded-lg border-red-500 dark:border-red-400 bg-red-50 dark:bg-red-900 pl-4 pt-5 pb-5 pr-4 w-6/12">
+            <div className="flex flex-row">
+              <XCircleIcon className="text-red-600 dark:text-red-400 w-6 h-6" />
+              <h1 className="ml-4 text-base leading-6 font-normal text-red-600 dark:text-red-400">
+                <Trans
+                i18nKey="connectPage.tabs.bluetooth.portOption"
+                values={{ deviceName: name }}
+                />
+              </h1>
+            </div>
+            <h2 className="pl-6 pr-2 ml-4 text-sm leading-5 font-light text-red-600 dark:text-red-500 mt-0.5">
+              <i>{connectionState.message}</i>
+            </h2>
+          </div>
+        </div>
+      );
+
+    default: // "IDLE"
+      return (
+        <button
+          className="hover:cursor-pointer"
+          type="button"
+          onClick={() => onClick(name)}
+        >
+          <div className="flex justify-center select-none">
+            <div className="flex flex-1 justify-left border rounded-lg border-gray-400 dark:border-gray-200 pl-4 pt-5 pb-5 pr-4 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-500 dark:hover:border-gray-50 hover:shadow-lg">
+              <Bluetooth className="text-gray-500 dark:text-gray-400 w-6 h-6" />
+              <h1 className="ml-4 text-base leading-6 font-normal text-gray-600 dark:text-gray-300 mt-0.5">
+                <Trans
+                i18nKey="connectPage.tabs.bluetooth.portOption"
+                values={{ deviceName: name }}
+                />
+              </h1>
+            </div>
+          </div>
+        </button>
+      );
+  }
+};

--- a/src/components/pages/ConnectPage.tsx
+++ b/src/components/pages/ConnectPage.tsx
@@ -56,7 +56,7 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
   const [isAdvancedOpen, setAdvancedOpen] = useState(false);
 
   // Connection-level state, held here to persist across tab switches
-  const [selectedBluetoothName, setSelectedBluetoothName] = useState("mxie_2128");
+  const [selectedBluetoothName, setSelectedBluetoothName] = useState("");
   const [selectedPortName, setSelectedPortName] = useState("");
   const [socketAddress, setSocketAddress] = useState("");
   const [socketPort, setSocketPort] = useState("4403");

--- a/src/components/pages/ConnectPage.tsx
+++ b/src/components/pages/ConnectPage.tsx
@@ -9,6 +9,7 @@ import Hero_Image from "@app/assets/onboard_hero_image.jpg";
 import { ConnectTab } from "@components/connection/ConnectTab";
 import { SerialConnectPane } from "@components/connection/SerialConnectPane";
 import { TcpConnectPane } from "@components/connection/TcpConnectPane";
+import { BluetoothConnectPane } from "@components/connection/BluetoothConnectPane";
 
 import { useAppConfigApi } from "@features/appConfig/api";
 import { selectPersistedTCPConnectionMeta } from "@features/appConfig/selectors";
@@ -51,6 +52,7 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
   const [isAdvancedOpen, setAdvancedOpen] = useState(false);
 
   // Connection-level state, held here to persist across tab switches
+  const [selectedBluetoothName, setSelectedBluetoothName] = useState("");
   const [selectedPortName, setSelectedPortName] = useState("");
   const [socketAddress, setSocketAddress] = useState("");
   const [socketPort, setSocketPort] = useState("4403");
@@ -106,6 +108,14 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
     );
     dispatch(connectionSliceActions.clearAllConnectionState());
     requestPorts();
+  };
+
+  const handleBluetoothSelected = (bluetoothName: string) => {
+    setSelectedBluetoothName(bluetoothName);
+    deviceApi.connectToDevice({
+      params: { type: ConnectionType.BLUETOOTH, bluetoothName },
+      setPrimary: true,
+    });
   };
 
   const handlePortSelected = (portName: string) => {
@@ -214,6 +224,11 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
               aria-label="Choose a connection type"
             >
               <ConnectTab
+                label={t("connectPage.tabs.bluetooth.title")}
+                tooltip={t("connectPage.tabs.bluetooth.tooltip")}
+                value={ConnectionType.BLUETOOTH}
+              />
+              <ConnectTab
                 label={t("connectPage.tabs.serial.title")}
                 tooltip={t("connectPage.tabs.serial.tooltip")}
                 value={ConnectionType.SERIAL}
@@ -224,6 +239,24 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
                 value={ConnectionType.TCP}
               />
             </Tabs.List>
+
+            <Tabs.Content value={ConnectionType.BLUETOOTH}>
+              <BluetoothConnectPane
+                availableSerialPorts={availableSerialPorts}
+                activePort={activePort}
+                activePortState={activePortState}
+                handlePortSelected={handlePortSelected}
+                refreshPorts={refreshPorts}
+                isAdvancedOpen={isAdvancedOpen}
+                setAdvancedOpen={setAdvancedOpen}
+                baudRate={baudRate}
+                setBaudRate={setBaudRate}
+                dtr={dtr}
+                setDtr={setDtr}
+                rts={rts}
+                setRts={setRts}
+              />
+            </Tabs.Content>
 
             <Tabs.Content value={ConnectionType.SERIAL}>
               <SerialConnectPane

--- a/src/components/pages/ConnectPage.tsx
+++ b/src/components/pages/ConnectPage.tsx
@@ -19,6 +19,7 @@ import { DeviceApiActions, useDeviceApi } from "@features/device/api";
 import {
   selectAutoConnectBluetooth,
   selectAutoConnectPort,
+  selectAvailableBluetoothDevices,
   selectAvailablePorts,
 } from "@features/device/selectors";
 import { requestSliceActions } from "@features/requests/slice";
@@ -45,6 +46,7 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
   const { isDarkMode } = useIsDarkMode();
 
   const dispatch = useDispatch();
+  const availableBluetoothDevices = useSelector(selectAvailableBluetoothDevices());
   const availableSerialPorts = useSelector(selectAvailablePorts());
   const autoConnectPort = useSelector(selectAutoConnectPort());
   const autoConnectBluetooth = useSelector(selectAutoConnectBluetooth());
@@ -88,6 +90,10 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
     selectPersistedTCPConnectionMeta(),
   );
 
+  const requestBluetoothDevices = useCallback(() => {
+    deviceApi.getAvailableBluetoothDevices();
+  }, [dispatch]);
+
   const requestPorts = useCallback(() => {
     deviceApi.getAvailableSerialPorts();
   }, [dispatch]);
@@ -117,6 +123,7 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
     );
     dispatch(connectionSliceActions.clearAllConnectionState());
     requestPorts();
+    requestBluetoothDevices();
   };
 
   const handleBluetoothSelected = (bluetoothName: string) => {
@@ -146,6 +153,7 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
     appConfigApi.fetchLastTcpConnectionMeta();
 
     requestPorts();
+    requestBluetoothDevices();
   }, [dispatch, requestPorts]);
 
   // Initialize TCP state to persisted state
@@ -252,7 +260,7 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
 
             <Tabs.Content value={ConnectionType.BLUETOOTH}>
               <BluetoothConnectPane
-                availableSerialPorts={availableSerialPorts}
+                availableBluetoothDevices={availableBluetoothDevices}
                 activePort={activeBluetooth}
                 activePortState={activeBluetoothState}
                 handlePortSelected={handleBluetoothSelected}

--- a/src/components/pages/ConnectPage.tsx
+++ b/src/components/pages/ConnectPage.tsx
@@ -17,6 +17,7 @@ import { selectConnectionStatus } from "@features/connection/selectors";
 import { connectionSliceActions } from "@features/connection/slice";
 import { DeviceApiActions, useDeviceApi } from "@features/device/api";
 import {
+  selectAutoConnectBluetooth,
   selectAutoConnectPort,
   selectAvailablePorts,
 } from "@features/device/selectors";
@@ -46,16 +47,24 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
   const dispatch = useDispatch();
   const availableSerialPorts = useSelector(selectAvailablePorts());
   const autoConnectPort = useSelector(selectAutoConnectPort());
+  const autoConnectBluetooth = useSelector(selectAutoConnectBluetooth());
 
   // UI state
   const [isScreenActive, setScreenActive] = useState(true);
   const [isAdvancedOpen, setAdvancedOpen] = useState(false);
 
   // Connection-level state, held here to persist across tab switches
-  const [selectedBluetoothName, setSelectedBluetoothName] = useState("");
+  const [selectedBluetoothName, setSelectedBluetoothName] = useState("mxie_2128");
   const [selectedPortName, setSelectedPortName] = useState("");
   const [socketAddress, setSocketAddress] = useState("");
   const [socketPort, setSocketPort] = useState("4403");
+
+  // autoConnectPort takes priority over selectedPortName if it exists
+  const activeBluetooth = autoConnectBluetooth ?? selectedBluetoothName;
+
+  const activeBluetoothState = useSelector(selectConnectionStatus(activeBluetooth)) ?? {
+    status: "IDLE",
+  };
 
   // Advanced serial options, held here to persist across tab switches
   const [baudRate, setBaudRate] = useState(115_200);
@@ -151,6 +160,7 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
   // Wait to allow user to recognize serial connection succeeded
   useEffect(() => {
     if (
+      activeBluetoothState.status !== "SUCCESSFUL" &&
       activePortState.status !== "SUCCESSFUL" &&
       activeSocketState.status !== "SUCCESSFUL"
     )
@@ -163,7 +173,7 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
     return () => {
       clearTimeout(delayHandle);
     };
-  }, [activePortState, activeSocketState]);
+  }, [activeBluetoothState, activePortState, activeSocketState]);
 
   // Move to main page upon successful port connection (need to trigger when port is succesfully connected)
   useEffect(() => {
@@ -243,18 +253,10 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
             <Tabs.Content value={ConnectionType.BLUETOOTH}>
               <BluetoothConnectPane
                 availableSerialPorts={availableSerialPorts}
-                activePort={activePort}
-                activePortState={activePortState}
-                handlePortSelected={handlePortSelected}
+                activePort={activeBluetooth}
+                activePortState={activeBluetoothState}
+                handlePortSelected={handleBluetoothSelected}
                 refreshPorts={refreshPorts}
-                isAdvancedOpen={isAdvancedOpen}
-                setAdvancedOpen={setAdvancedOpen}
-                baudRate={baudRate}
-                setBaudRate={setBaudRate}
-                dtr={dtr}
-                setDtr={setDtr}
-                rts={rts}
-                setRts={setRts}
               />
             </Tabs.Content>
 

--- a/src/features/device/api.ts
+++ b/src/features/device/api.ts
@@ -21,6 +21,7 @@ import { CommandError, throwError } from "@utils/errors";
 export enum DeviceApiActions {
   GetAutoConnectPort = "device/getAutoConnectPort",
   SubscribeAll = "device/subscribeAll",
+  GetAvailableBluetoothDevices = "device/getAvailableBluetoothDevices",
   GetAvailableSerialPorts = "device/getAvailableSerialPorts",
   InitializeApplication = "device/initializeApplication",
   ConnectToDevice = "device/connectToDevice",
@@ -55,6 +56,16 @@ export const useDeviceApi = () => {
           setPrimary: true,
         });
       }
+    });
+  };
+
+  const getAvailableBluetoothDevices = async () => {
+    const TYPE = DeviceApiActions.GetAvailableBluetoothDevices;
+
+    await trackRequestOperation(TYPE, dispatch, async () => {
+      const bluetoothDevices = await backendConnectionApi.getAllBluetooth();
+
+      dispatch(deviceSliceActions.setAvailableBluetoothDevices(bluetoothDevices));
     });
   };
 
@@ -260,6 +271,7 @@ export const useDeviceApi = () => {
 
   return {
     getAutoConnectPort,
+    getAvailableBluetoothDevices,
     getAvailableSerialPorts,
     connectToDevice,
     disconnectFromDevice,

--- a/src/features/device/api.ts
+++ b/src/features/device/api.ts
@@ -85,12 +85,20 @@ export const useDeviceApi = () => {
   }) => {
     const TYPE = DeviceApiActions.ConnectToDevice;
 
-    const deviceKey: DeviceKey =
-      payload.params.type === ConnectionType.SERIAL
-        ? payload.params.portName
-        : payload.params.type === ConnectionType.TCP
-          ? payload.params.socketAddress
-          : throwError("Neither portName nor socketAddress were set");
+    let deviceKey: DeviceKey
+    switch (payload.params.type) {
+      case ConnectionType.BLUETOOTH:
+        deviceKey = payload.params.bluetoothName
+        break
+      case ConnectionType.SERIAL:
+        deviceKey = payload.params.portName
+        break
+      case ConnectionType.TCP:
+        deviceKey = payload.params.socketAddress
+        break
+      default:
+        throwError("Neither bluetoothName, portName nor socketAddress were set");
+    }
 
     await trackRequestOperation(
       TYPE,
@@ -109,6 +117,9 @@ export const useDeviceApi = () => {
           await backendConnectionApi.connectToBluetooth(
             payload.params.bluetoothName,
           );
+          // await backendConnectionApi.connectToBluetooth(
+          //   payload.params.bluetoothName,
+          // );
         }
 
         if (payload.params.type === ConnectionType.SERIAL) {
@@ -127,6 +138,14 @@ export const useDeviceApi = () => {
         }
 
         if (payload.setPrimary) {
+          if (payload.params.type === ConnectionType.BLUETOOTH) {
+            dispatch(
+              deviceSliceActions.setPrimaryDeviceConnectionKey(
+                payload.params.bluetoothName,
+              ),
+            );
+          }
+
           if (payload.params.type === ConnectionType.SERIAL) {
             dispatch(
               deviceSliceActions.setPrimaryDeviceConnectionKey(

--- a/src/features/device/api.ts
+++ b/src/features/device/api.ts
@@ -71,6 +71,10 @@ export const useDeviceApi = () => {
   const connectToDevice = async (payload: {
     params:
       | {
+          type: ConnectionType.BLUETOOTH;
+          bluetoothName: string;
+        }
+      | {
           type: ConnectionType.SERIAL;
           portName: string;
           dtr: boolean;
@@ -100,6 +104,12 @@ export const useDeviceApi = () => {
             },
           }),
         );
+
+        if (payload.params.type === ConnectionType.BLUETOOTH) {
+          await backendConnectionApi.connectToBluetooth(
+            payload.params.bluetoothName,
+          );
+        }
 
         if (payload.params.type === ConnectionType.SERIAL) {
           await backendConnectionApi.connectToSerialPort(

--- a/src/features/device/selectors.ts
+++ b/src/features/device/selectors.ts
@@ -8,6 +8,11 @@ import type {
   meshtastic_protobufs_User,
 } from "@bindings/index";
 
+export const selectAvailableBluetoothDevices =
+  () =>
+  (state: RootState): string[] | null =>
+    state.devices.availableBluetoothDevices;
+
 export const selectAvailablePorts =
   () =>
   (state: RootState): string[] | null =>

--- a/src/features/device/selectors.ts
+++ b/src/features/device/selectors.ts
@@ -100,3 +100,6 @@ export const selectWaypointByLocation =
 
 export const selectAutoConnectPort = () => (state: RootState) =>
   state.devices.autoConnectPort;
+
+export const selectAutoConnectBluetooth = () => (state: RootState) =>
+  state.devices.autoConnectBluetooth;

--- a/src/features/device/slice.ts
+++ b/src/features/device/slice.ts
@@ -7,6 +7,7 @@ export interface IDeviceState {
   availableSerialPorts: string[] | null;
   primaryDeviceKey: string | null; // port or socket ddress
   autoConnectPort: string | null; // Port to automatically connect to on startup
+  autoConnectBluetooth: string | null;
 }
 
 export const initialDeviceState: IDeviceState = {
@@ -14,6 +15,7 @@ export const initialDeviceState: IDeviceState = {
   availableSerialPorts: null,
   primaryDeviceKey: null,
   autoConnectPort: null,
+  autoConnectBluetooth: null
 };
 
 export const deviceSlice = createSlice({

--- a/src/features/device/slice.ts
+++ b/src/features/device/slice.ts
@@ -4,6 +4,7 @@ import type { app_device_MeshDevice } from "@bindings/index";
 
 export interface IDeviceState {
   device: app_device_MeshDevice | null;
+  availableBluetoothDevices: string[] | null;
   availableSerialPorts: string[] | null;
   primaryDeviceKey: string | null; // port or socket ddress
   autoConnectPort: string | null; // Port to automatically connect to on startup
@@ -12,6 +13,7 @@ export interface IDeviceState {
 
 export const initialDeviceState: IDeviceState = {
   device: null,
+  availableBluetoothDevices: null,
   availableSerialPorts: null,
   primaryDeviceKey: null,
   autoConnectPort: null,
@@ -22,6 +24,12 @@ export const deviceSlice = createSlice({
   name: "device",
   initialState: initialDeviceState,
   reducers: {
+    setAvailableBluetoothDevices: (
+      state,
+      action: PayloadAction<string[] | null>,
+    ) => {
+      state.availableBluetoothDevices = action.payload;
+    },
     setAvailableSerialPorts: (
       state,
       action: PayloadAction<string[] | null>,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -34,6 +34,16 @@
         "port": "Port",
         "connect": "Connect",
         "connecting": "Connecting..."
+      },
+      "bluetooth": {
+        "title": "Bluetooth",
+        "tooltip": "Connect to your radio via Bluetooth",
+        "device": "Device Name",
+        "connect": "Connect",
+        "connecting": "Connecting...",
+        "portOption": "Bluetooth device {{deviceName}}",
+        "empty": "No devices detected.",
+        "refresh": "Refresh devices"
       }
     }
   },

--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -3,4 +3,5 @@ export type DeviceKey = string;
 export enum ConnectionType {
   SERIAL = "SERIAL",
   TCP = "TCP",
+  BLUETOOTH = "BLUETOOTH",
 }


### PR DESCRIPTION
Adds basic support for connecting to Meshtastic radios via Bluetooth LE.

<img width="1025" alt="Screenshot 2025-07-06 at 7 28 12 PM" src="https://github.com/user-attachments/assets/b3a44f40-3cb4-4f78-9ebc-5f9f5a09048f" />

- Uses the latest revision of `meshtastic/rust`. This will eventually be released, but currently it's just pinned to a commit hash.
- Includes an update to the Meshtastic protobufs in the client.

- [x] MacOS testing
- [ ] Linux testing
- [ ] Windows testing