### PR TITLE
fix(ui): :bug: resolve node info misalignment in map view

### DIFF
--- a/src/components/Map/MapSelectedNodeMenu.tsx
+++ b/src/components/Map/MapSelectedNodeMenu.tsx
@@ -83,7 +83,7 @@ export const MapSelectedNodeMenu = () => {
   return (
     <div className="absolute top-24 right-9 bg-white dark:bg-gray-800 p-5 pl-4 rounded-lg drop-shadow-lg w-80 z-[inherit]">
       <div className="flex justify-between">
-        <h1 className="text-gray-600 dark:text-gray-400 text-2xl leading-5 font-semibold">
+        <h1 className="text-gray-600 dark:text-gray-400 text-2xl leading-6 font-semibold break-all">
           {deviceName}
         </h1>
         <button type="button" onClick={clearActiveNode}>

--- a/src/components/NodeSearch/NodeSearchResult.tsx
+++ b/src/components/NodeSearch/NodeSearchResult.tsx
@@ -37,9 +37,9 @@ export const NodeSearchResult = ({
   return (
     <div className="flex flex-row gap-4">
       <div className={`flex-grow ${colorClasses.text}`}>
-        <p className="text-lg font-semibold whitespace-nowrap overflow-hidden text-ellipsis">
-          {node.user?.longName ?? node.nodeNum}
-          <span className="pl-2 text-xs font-normal">
+        <p className="flex flex-grow items-center text-lg whitespace-nowrap overflow-hidden">
+          <span className="w-full max-w-[176px] font-semibold truncate">{node.user?.longName ?? node.nodeNum}</span>
+          <span className="pl-4 flex-1 text-xs font-normal">
             {lastPacketTime ? (
               <TimeAgo
                 datetime={lastPacketTime * 1000}


### PR DESCRIPTION
Resolve bugs related to text overflow and misalignment in the Map View components.

i. `NodeSearchResult` component now lists node correctly with ellipsis
when the text is too long.

> The related element is now wrapped in a container with a fixed width
> (`11rem`-equivalent) and appended `.truncate` into the class list.
> PS - the Tailwind `.truncate` utility class is equivalent to the combination of
> `.overflow-hidden`, `.text-ellipsis`, and `.whitespace-nowrap`.

ii. `MapSelectedNodeMenu` component now properly wraps the device name
element and does not overflow the container.

> The related element now allows text to wrap onto the next line if exceeding
> container's width by applying Tailwind `.break-all` utility class.

Fix #511.