### PR TITLE
feat: add connection status, disconnect button, and recent tcp connections list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Outlet, Route, Routes } from "react-router-dom";
 
 import { Sidebar } from "@components/Sidebar/Sidebar";
 import { SplashScreen } from "@components/SplashScreen/SplashScreen";
+import { useRecentConnectionTracker } from "@app/hooks/useRecentConnectionTracker";
 
 import { ModuleConfigPage } from "@app/components/pages/config/ModuleConfigPage";
 import { ApplicationStatePage } from "@components/pages/ApplicationStatePage";
@@ -19,9 +20,9 @@ import { GraphDebuggerPage } from "@components/pages/GraphDebuggerPage";
 
 import { AppRoutes } from "@utils/routing";
 
-const AppWrapper = () => (
+const AppWrapper = ({ onShowConnect }: { onShowConnect: () => void }) => (
   <>
-    <Sidebar />
+    <Sidebar onShowConnect={onShowConnect} />
     <Outlet />
   </>
 );
@@ -33,6 +34,8 @@ export const App = () => {
   const [isSplashMounted, setSplashMounted] = useState(splashEnabled);
   const [isOnboardMounted, setOnboardMounted] = useState(true);
 
+  useRecentConnectionTracker();
+
   const handleSplashUnmount = () => {
     setSplashMounted(false);
   };
@@ -41,13 +44,20 @@ export const App = () => {
     setOnboardMounted(false);
   };
 
+  const handleShowConnect = () => {
+    setOnboardMounted(true);
+  };
+
   return (
     <div className="flex flex-row relative">
       {isSplashMounted && <SplashScreen unmountSelf={handleSplashUnmount} />}
       {isOnboardMounted && <ConnectPage unmountSelf={handleOnboardUnmount} />}
 
       <Routes>
-        <Route path="/" element={<AppWrapper />}>
+        <Route
+          path="/"
+          element={<AppWrapper onShowConnect={handleShowConnect} />}
+        >
           <Route index element={<MapPage />} />
           <Route path={AppRoutes.MESSAGING} element={<MessagingPage />} />
 

--- a/src/components/Sidebar/ConnectionStatus.tsx
+++ b/src/components/Sidebar/ConnectionStatus.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Wifi, WifiOff, Usb } from "lucide-react";
+import { Wifi, Usb, Bluetooth, Unlink } from "lucide-react";
 
 import { useDeviceApi } from "@features/device/api";
 import {
@@ -15,9 +15,13 @@ import { ConnectionType } from "@utils/connections";
 
 export interface IConnectionStatusProps {
   onDisconnect: () => void;
+  isCollapsed?: boolean;
 }
 
-export const ConnectionStatus = ({ onDisconnect }: IConnectionStatusProps) => {
+export const ConnectionStatus = ({
+  onDisconnect,
+  isCollapsed = false,
+}: IConnectionStatusProps) => {
   const { t } = useTranslation();
   const deviceApi = useDeviceApi();
 
@@ -40,6 +44,9 @@ export const ConnectionStatus = ({ onDisconnect }: IConnectionStatusProps) => {
     if (connectionType === ConnectionType.SERIAL) {
       return <Usb className="w-4 h-4" />;
     }
+    if (connectionType === ConnectionType.BLUETOOTH) {
+      return <Bluetooth className="w-4 h-4" />;
+    }
     return <Wifi className="w-4 h-4" />;
   };
 
@@ -49,54 +56,81 @@ export const ConnectionStatus = ({ onDisconnect }: IConnectionStatusProps) => {
         method: t("connectPage.tabs.serial.title"),
         address: primaryDeviceKey,
       };
-    } else {
+    }
+    if (connectionType === ConnectionType.BLUETOOTH) {
       return {
-        method: t("connectPage.tabs.tcp.title"),
+        method: t("connectPage.tabs.bluetooth.title"),
         address: primaryDeviceKey,
       };
     }
+    return {
+      method: t("connectPage.tabs.tcp.title"),
+      address: primaryDeviceKey,
+    };
   };
 
   const connectionDetails = getConnectionDetails();
 
   return (
-    <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-700">
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-          {getConnectionIcon()}
-          <span>{connectionDetails.method}</span>
-        </div>
-        <div className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
-          <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-          <span>{t("general.connected")}</span>
-        </div>
-      </div>
-
-      <div className="text-sm text-gray-700 dark:text-gray-300 mb-1">
-        <div className="font-medium truncate">
-          {connectedUser?.longName ||
-            connectedUser?.shortName ||
-            "Unknown Node"}
-        </div>
-        <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
-          {connectedUser?.shortName &&
-            connectedUser?.longName !== connectedUser?.shortName &&
-            `(${connectedUser.shortName})`}
-        </div>
-      </div>
-
-      <div className="text-xs text-gray-500 dark:text-gray-400 mb-3 truncate">
-        {connectionDetails.address}
-      </div>
-
-      <button
-        type="button"
-        onClick={handleDisconnect}
-        className="w-full flex items-center justify-center gap-2 px-3 py-1.5 text-xs font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors"
+    <div
+      className={`border-b border-gray-100 dark:border-gray-700 transition-all duration-300 ease-in-out overflow-hidden flex flex-col justify-end ${
+        isCollapsed ? "h-[65px] py-2" : "h-[150px] py-3"
+      }`}
+    >
+      <div
+        className="flex flex-col transition-opacity duration-300 ease-in-out"
+        style={
+          isCollapsed
+            ? { opacity: 0, pointerEvents: "none" }
+            : { opacity: 1, pointerEvents: "auto" }
+        }
       >
-        <WifiOff className="w-3 h-3" />
-        {t("general.disconnect")}
-      </button>
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+            {getConnectionIcon()}
+            <span>{connectionDetails.method}</span>
+          </div>
+          <div className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+            <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+            <span>{t("general.connected")}</span>
+          </div>
+        </div>
+
+        <div className="text-sm text-gray-700 dark:text-gray-300 mb-1">
+          <div className="font-medium truncate">
+            {connectedUser?.longName ||
+              connectedUser?.shortName ||
+              "Unknown Node"}
+          </div>
+          <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+            {connectedUser?.shortName &&
+              connectedUser?.longName !== connectedUser?.shortName &&
+              `(${connectedUser.shortName})`}
+          </div>
+        </div>
+
+        <div className="text-xs text-gray-500 dark:text-gray-400 mb-3 truncate">
+          {connectionDetails.address}
+        </div>
+      </div>
+
+      <div
+        className={`flex ${isCollapsed ? "justify-center mb-[7px]" : "w-full mb-[3px]"} transition-all duration-300 ease-in-out`}
+      >
+        <button
+          type="button"
+          onClick={handleDisconnect}
+          className={`flex items-center justify-center gap-2 text-xs font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md hover:bg-red-100 dark:hover:bg-red-900/30 transition-all duration-300 ease-in-out ${
+            isCollapsed ? "p-2" : "w-full px-3 py-1.5"
+          }`}
+          title={isCollapsed ? t("general.disconnect") : undefined}
+        >
+          <Unlink
+            className={`${isCollapsed ? "w-4 h-4" : "w-3 h-3"} transition-all duration-300 ease-in-out`}
+          />
+          {!isCollapsed && t("general.disconnect")}
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/components/Sidebar/ConnectionStatus.tsx
+++ b/src/components/Sidebar/ConnectionStatus.tsx
@@ -1,0 +1,102 @@
+import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+import { Wifi, WifiOff, Usb } from "lucide-react";
+
+import { useDeviceApi } from "@features/device/api";
+import {
+  selectDevice,
+  selectPrimaryDeviceKey,
+  selectPrimaryConnectionType,
+  selectConnectedDeviceNodeId,
+  selectUserByNodeId,
+} from "@features/device/selectors";
+
+import { ConnectionType } from "@utils/connections";
+
+export interface IConnectionStatusProps {
+  onDisconnect: () => void;
+}
+
+export const ConnectionStatus = ({ onDisconnect }: IConnectionStatusProps) => {
+  const { t } = useTranslation();
+  const deviceApi = useDeviceApi();
+
+  const device = useSelector(selectDevice());
+  const primaryDeviceKey = useSelector(selectPrimaryDeviceKey());
+  const connectionType = useSelector(selectPrimaryConnectionType());
+  const connectedNodeId = useSelector(selectConnectedDeviceNodeId());
+  const connectedUser = useSelector(selectUserByNodeId(connectedNodeId ?? 0));
+
+  if (!device || !primaryDeviceKey || !connectionType) {
+    return null;
+  }
+
+  const handleDisconnect = async () => {
+    await deviceApi.disconnectFromAllDevices();
+    onDisconnect();
+  };
+
+  const getConnectionIcon = () => {
+    if (connectionType === ConnectionType.SERIAL) {
+      return <Usb className="w-4 h-4" />;
+    }
+    return <Wifi className="w-4 h-4" />;
+  };
+
+  const getConnectionDetails = () => {
+    if (connectionType === ConnectionType.SERIAL) {
+      return {
+        method: t("connectPage.tabs.serial.title"),
+        address: primaryDeviceKey,
+      };
+    } else {
+      return {
+        method: t("connectPage.tabs.tcp.title"),
+        address: primaryDeviceKey,
+      };
+    }
+  };
+
+  const connectionDetails = getConnectionDetails();
+
+  return (
+    <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+          {getConnectionIcon()}
+          <span>{connectionDetails.method}</span>
+        </div>
+        <div className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+          <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+          <span>{t("general.connected")}</span>
+        </div>
+      </div>
+
+      <div className="text-sm text-gray-700 dark:text-gray-300 mb-1">
+        <div className="font-medium truncate">
+          {connectedUser?.longName ||
+            connectedUser?.shortName ||
+            "Unknown Node"}
+        </div>
+        <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+          {connectedUser?.shortName &&
+            connectedUser?.longName !== connectedUser?.shortName &&
+            `(${connectedUser.shortName})`}
+        </div>
+      </div>
+
+      <div className="text-xs text-gray-500 dark:text-gray-400 mb-3 truncate">
+        {connectionDetails.address}
+      </div>
+
+      <button
+        type="button"
+        onClick={handleDisconnect}
+        className="w-full flex items-center justify-center gap-2 px-3 py-1.5 text-xs font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors"
+      >
+        <WifiOff className="w-3 h-3" />
+        {t("general.disconnect")}
+      </button>
+    </div>
+  );
+};

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -21,12 +21,13 @@ import {
 import { SidebarIcon } from "@components/Sidebar/SidebarIcon";
 import { SidebarLogo } from "@components/Sidebar/SidebarLogo";
 import { SidebarTab } from "@components/Sidebar/SidebarTab";
+import { ConnectionStatus } from "@components/Sidebar/ConnectionStatus";
 
 import { AppRoutes } from "@utils/routing";
 
 import "@components/Sidebar/Sidebar.css";
 
-export const Sidebar = () => {
+export const Sidebar = ({ onShowConnect }: { onShowConnect?: () => void }) => {
   const { t } = useTranslation();
 
   const [isSidebarExpanded, setSidebarExpanded] = useState(true);
@@ -43,6 +44,10 @@ export const Sidebar = () => {
       }`}
     >
       <SidebarLogo isSidebarExpanded={isSidebarExpanded} />
+
+      {isSidebarExpanded && onShowConnect && (
+        <ConnectionStatus onDisconnect={onShowConnect} />
+      )}
 
       <div className="flex flex-col flex-1 justify-between px-4 pt-4 pb-1 overflow-y-auto hide-scrollbar">
         <div className="flex flex-col gap-6 mb-6">

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -45,10 +45,6 @@ export const Sidebar = ({ onShowConnect }: { onShowConnect?: () => void }) => {
     >
       <SidebarLogo isSidebarExpanded={isSidebarExpanded} />
 
-      {isSidebarExpanded && onShowConnect && (
-        <ConnectionStatus onDisconnect={onShowConnect} />
-      )}
-
       <div className="flex flex-col flex-1 justify-between px-4 pt-4 pb-1 overflow-y-auto hide-scrollbar">
         <div className="flex flex-col gap-6 mb-6">
           <SidebarTab
@@ -169,6 +165,13 @@ export const Sidebar = ({ onShowConnect }: { onShowConnect?: () => void }) => {
 
       <div className="flex flex-col mt-auto justify-between px-4 pt-4 pb-1">
         <hr className="border-gray-100 dark:border-gray-700" />
+
+        {onShowConnect && (
+          <ConnectionStatus
+            onDisconnect={onShowConnect}
+            isCollapsed={!isSidebarExpanded}
+          />
+        )}
 
         <SidebarIcon
           name={isSidebarExpanded ? t("sidebar.collapse") : t("sidebar.expand")}

--- a/src/components/connection/RecentConnectPane.tsx
+++ b/src/components/connection/RecentConnectPane.tsx
@@ -1,0 +1,52 @@
+import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+
+import { RecentConnectionCard } from "@components/connection/RecentConnectionCard";
+
+import { selectRecentConnections } from "@features/appConfig/selectors";
+import type { RecentConnection } from "@features/appConfig/slice";
+
+export interface IRecentConnectPaneProps {
+  onConnect: (connection: RecentConnection) => void;
+  onRemove: (connection: RecentConnection) => void;
+}
+
+export const RecentConnectPane = ({
+  onConnect,
+  onRemove,
+}: IRecentConnectPaneProps) => {
+  const { t } = useTranslation();
+  const recentConnections = useSelector(selectRecentConnections());
+
+  if (recentConnections.length === 0) {
+    return (
+      <div className="p-6 text-center text-gray-500 dark:text-gray-400">
+        <p>{t("recentConnections.noRecent")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <div className="mb-4">
+        <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300">
+          {t("recentConnections.title")}
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {t("recentConnections.subtitle")}
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {recentConnections.map((connection) => (
+          <RecentConnectionCard
+            key={connection.id}
+            connection={connection}
+            onConnect={onConnect}
+            onRemove={onRemove}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/connection/RecentConnectionCard.tsx
+++ b/src/components/connection/RecentConnectionCard.tsx
@@ -1,0 +1,100 @@
+import { useTranslation } from "react-i18next";
+import { Wifi, Clock, Trash2 } from "lucide-react";
+
+import type { RecentConnection } from "@features/appConfig/slice";
+
+export interface IRecentConnectionCardProps {
+  connection: RecentConnection;
+  onConnect: (connection: RecentConnection) => void;
+  onRemove: (connection: RecentConnection) => void;
+}
+
+export const RecentConnectionCard = ({
+  connection,
+  onConnect,
+  onRemove,
+}: IRecentConnectionCardProps) => {
+  const { t } = useTranslation();
+
+  const getConnectionIcon = () => {
+    return <Wifi className="w-4 h-4" />;
+  };
+
+  const getConnectionTypeLabel = () => {
+    return t("connectPage.tabs.tcp.title");
+  };
+
+  const formatLastConnected = () => {
+    const now = Date.now();
+    const diffMs = now - connection.lastConnected;
+    const diffMins = Math.floor(diffMs / (1000 * 60));
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffMins < 1) {
+      return t("recentConnections.justNow");
+    } else if (diffMins < 60) {
+      return t("recentConnections.minutesAgo", { count: diffMins });
+    } else if (diffHours < 24) {
+      return t("recentConnections.hoursAgo", { count: diffHours });
+    } else {
+      return t("recentConnections.daysAgo", { count: diffDays });
+    }
+  };
+
+  const handleConnect = () => {
+    onConnect(connection);
+  };
+
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRemove(connection);
+  };
+
+  return (
+    <div className="relative w-full p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-colors">
+      <button
+        type="button"
+        onClick={handleConnect}
+        className="w-full text-left"
+      >
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+            {getConnectionIcon()}
+            <span>{getConnectionTypeLabel()}</span>
+          </div>
+          <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+            <Clock className="w-3 h-3" />
+            <span>{formatLastConnected()}</span>
+          </div>
+        </div>
+
+        <div className="text-sm text-gray-700 dark:text-gray-300 mb-1">
+          <div className="font-medium truncate">
+            {connection.deviceName || "Unknown Device"}
+          </div>
+          {connection.shortName &&
+            connection.longName !== connection.shortName && (
+              <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                ({connection.shortName})
+              </div>
+            )}
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+            {connection.address}
+          </div>
+          <button
+            type="button"
+            onClick={handleRemove}
+            className="ml-2 p-1 rounded-md bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors"
+            title="Remove connection"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      </button>
+    </div>
+  );
+};

--- a/src/components/connection/TcpConnectPane.tsx
+++ b/src/components/connection/TcpConnectPane.tsx
@@ -1,11 +1,14 @@
-import {
-  EllipsisHorizontalCircleIcon,
-  LinkIcon,
-} from "@heroicons/react/24/outline";
+import { LinkIcon } from "@heroicons/react/24/outline";
+import { Loader2 } from "lucide-react";
 import type { FormEventHandler } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
 
 import { ConnectionInput } from "@components/connection/ConnectionInput";
+import { RecentConnectionCard } from "@components/connection/RecentConnectionCard";
+import { selectRecentConnections } from "@features/appConfig/selectors";
+import type { RecentConnection } from "@features/appConfig/slice";
 import type { RequestStatus } from "@features/requests/slice";
 
 export interface ITcpConnectPaneProps {
@@ -15,6 +18,9 @@ export interface ITcpConnectPaneProps {
   setSocketPort: (socketPort: string) => void;
   activeSocketState: RequestStatus;
   handleSocketConnect: FormEventHandler;
+  onRecentConnectionSelect: (connection: RecentConnection) => void;
+  onRecentConnectionRemove: (connection: RecentConnection) => void;
+  onCancelConnection: () => void;
 }
 
 export const TcpConnectPane = ({
@@ -24,56 +30,113 @@ export const TcpConnectPane = ({
   setSocketPort,
   activeSocketState,
   handleSocketConnect,
+  onRecentConnectionSelect,
+  onRecentConnectionRemove,
+  onCancelConnection,
 }: ITcpConnectPaneProps) => {
   const { t } = useTranslation();
+  const recentConnections = useSelector(selectRecentConnections());
+
+  // Track if we've started connecting to maintain overlay until component unmounts
+  const [hasStartedConnecting, setHasStartedConnecting] = useState(false);
+
+  const handleCancelConnection = () => {
+    setHasStartedConnecting(false);
+    onCancelConnection();
+  };
+
+  // Show connecting overlay if we've started connecting (and maintain until component unmounts)
+  if (activeSocketState.status === "PENDING" || hasStartedConnecting) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[300px] p-8">
+        <div className="text-xl font-medium text-gray-700 dark:text-gray-300 mb-4">
+          Connecting to {socketAddress}:{socketPort}
+        </div>
+        <Loader2 className="w-8 h-8 text-blue-500 animate-spin mb-6" />
+        <button
+          type="button"
+          onClick={handleCancelConnection}
+          className="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  const handleFormSubmit: FormEventHandler = (e) => {
+    setHasStartedConnecting(true);
+    handleSocketConnect(e);
+  };
+
+  const handleRecentConnectionSelect = (connection: RecentConnection) => {
+    setHasStartedConnecting(true);
+    onRecentConnectionSelect(connection);
+  };
+
+  const handleRecentConnectionRemove = (connection: RecentConnection) => {
+    onRecentConnectionRemove(connection);
+  };
 
   return (
-    <form className="flex flex-col gap-4 mt-4" onSubmit={handleSocketConnect}>
-      <ConnectionInput
-        type="text"
-        placeholder={t("connectPage.tabs.tcp.ip")}
-        value={socketAddress}
-        onChange={(e) => setSocketAddress(e.target.value)}
-        disabled={activeSocketState.status === "PENDING"}
-      />
+    <div>
+      <form className="flex flex-col gap-4 mt-4" onSubmit={handleFormSubmit}>
+        <ConnectionInput
+          type="text"
+          placeholder={t("connectPage.tabs.tcp.ip")}
+          value={socketAddress}
+          onChange={(e) => setSocketAddress(e.target.value)}
+        />
 
-      <ConnectionInput
-        type="text"
-        placeholder={t("connectPage.tabs.tcp.port")}
-        value={socketPort}
-        onChange={(e) => setSocketPort(e.target.value)}
-        disabled={activeSocketState.status === "PENDING"}
-      />
+        <ConnectionInput
+          type="text"
+          placeholder={t("connectPage.tabs.tcp.port")}
+          value={socketPort}
+          onChange={(e) => setSocketPort(e.target.value)}
+        />
 
-      <button
-        className="flex flex-row flex-1 justify-center gap-3 border rounded-lg border-gray-400 dark:border-gray-500 mx-auto px-5 py-4 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-500 dark:hover:border-gray-400 hover:shadow-lg disabled:cursor-wait"
-        disabled={activeSocketState.status === "PENDING"}
-        type="submit"
-      >
-        {activeSocketState.status === "PENDING" ? (
-          <>
-            <EllipsisHorizontalCircleIcon className="w-6 h-6 text-gray-500 dark:text-gray-400" />
-            <p className="text-gray-700 dark:text-gray-300">
-              {t("connectPage.tabs.tcp.connecting")}
-            </p>
-          </>
-        ) : (
-          <>
-            <LinkIcon className="w-6 h-6 text-gray-500 dark:text-gray-400" />
-            <p className="text-gray-700 dark:text-gray-300">
-              {t("connectPage.tabs.tcp.connect")}
-            </p>
-          </>
-        )}
-      </button>
-
-      {activeSocketState.status === "FAILED" && (
-        <div>
-          <p className="pl-6 pr-2 ml-4 text-sm leading-5 font-light text-red-600 dark:text-red-400 my-1">
-            {activeSocketState.message}
+        <button
+          className="flex flex-row flex-1 justify-center gap-3 border rounded-lg border-gray-400 dark:border-gray-500 mx-auto px-5 py-4 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-500 dark:hover:border-gray-400 hover:shadow-lg disabled:cursor-wait"
+          type="submit"
+        >
+          <LinkIcon className="w-6 h-6 text-gray-600 dark:text-gray-300" />
+          <p className="text-gray-700 dark:text-gray-300">
+            {t("connectPage.tabs.tcp.connect")}
           </p>
+        </button>
+
+        {activeSocketState.status === "FAILED" && (
+          <div>
+            <p className="pl-6 pr-2 ml-4 text-sm leading-5 font-light text-red-600 dark:text-red-400 my-1">
+              {activeSocketState.message}
+            </p>
+          </div>
+        )}
+      </form>
+
+      {recentConnections.length > 0 && (
+        <div className="mt-6 pt-6 border-t border-gray-200 dark:border-gray-600">
+          <div className="mb-4">
+            <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300">
+              {t("recentConnections.title")}
+            </h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {t("recentConnections.subtitle")}
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            {recentConnections.map((connection) => (
+              <RecentConnectionCard
+                key={connection.id}
+                connection={connection}
+                onConnect={handleRecentConnectionSelect}
+                onRemove={handleRecentConnectionRemove}
+              />
+            ))}
+          </div>
         </div>
       )}
-    </form>
+    </div>
   );
 };

--- a/src/components/pages/ConnectPage.tsx
+++ b/src/components/pages/ConnectPage.tsx
@@ -11,7 +11,16 @@ import { SerialConnectPane } from "@components/connection/SerialConnectPane";
 import { TcpConnectPane } from "@components/connection/TcpConnectPane";
 
 import { useAppConfigApi } from "@features/appConfig/api";
-import { selectPersistedTCPConnectionMeta } from "@features/appConfig/selectors";
+import {
+  selectPersistedTCPConnectionMeta,
+  selectRecentConnections,
+  selectGeneralConfigState,
+} from "@features/appConfig/selectors";
+import {
+  appConfigSliceActions,
+  type RecentConnection,
+} from "@features/appConfig/slice";
+import { useRecentConnectionTracker } from "@app/hooks/useRecentConnectionTracker";
 import { selectConnectionStatus } from "@features/connection/selectors";
 import { connectionSliceActions } from "@features/connection/slice";
 import { DeviceApiActions, useDeviceApi } from "@features/device/api";
@@ -39,9 +48,13 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
   const appConfigApi = useAppConfigApi();
   const deviceApi = useDeviceApi();
 
+  useRecentConnectionTracker();
+
   const dispatch = useDispatch();
   const availableSerialPorts = useSelector(selectAvailablePorts());
   const autoConnectPort = useSelector(selectAutoConnectPort());
+  const recentConnections = useSelector(selectRecentConnections());
+  const generalConfig = useSelector(selectGeneralConfigState());
 
   // UI state
   const [isScreenActive, setScreenActive] = useState(true);
@@ -73,6 +86,9 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
   const persistedTCPConnectionMeta = useSelector(
     selectPersistedTCPConnectionMeta(),
   );
+
+  const defaultTabValue =
+    generalConfig?.selectedConnectionTab || ConnectionType.SERIAL;
 
   const requestPorts = useCallback(() => {
     deviceApi.getAvailableSerialPorts();
@@ -113,14 +129,69 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
     });
   };
 
+  const handleRecentConnectionSelect = (connection: RecentConnection) => {
+    const [address, portStr] = connection.address.split(":");
+    setSocketAddress(address);
+    setSocketPort(portStr);
+
+    appConfigApi.persistLastTcpConnectionMeta({
+      address,
+      port: parseInt(portStr),
+    });
+
+    deviceApi.connectToDevice({
+      params: {
+        type: ConnectionType.TCP,
+        socketAddress: connection.address,
+      },
+      setPrimary: true,
+    });
+  };
+
+  const handleRecentConnectionRemove = async (connection: RecentConnection) => {
+    dispatch(appConfigSliceActions.removeRecentConnection(connection.id));
+
+    const updatedConnections = recentConnections.filter(
+      (conn) => conn.id !== connection.id,
+    );
+
+    await appConfigApi.persistRecentConnections(updatedConnections);
+  };
+
+  const handleTabChange = (value: string) => {
+    const selectedTab = value as "SERIAL" | "TCP";
+    appConfigApi.persistGeneralConfig({
+      ...(generalConfig || {}),
+      selectedConnectionTab: selectedTab,
+    });
+  };
+
+  const handleCancelConnection = async () => {
+    await deviceApi.disconnectFromAllDevices();
+
+    // Clear both request state and connection state to hide the connecting overlay
+    dispatch(
+      requestSliceActions.clearRequestState({
+        name: DeviceApiActions.ConnectToDevice,
+      }),
+    );
+    dispatch(connectionSliceActions.clearAllConnectionState());
+  };
+
   const openExternalLink = (url: string) => () => {
     open(url);
   };
 
   useEffect(() => {
-    deviceApi.disconnectFromAllDevices();
-    deviceApi.getAutoConnectPort();
+    setScreenActive(true);
+    dispatch(
+      requestSliceActions.clearRequestState({
+        name: DeviceApiActions.ConnectToDevice,
+      }),
+    );
+    dispatch(connectionSliceActions.clearAllConnectionState());
 
+    deviceApi.disconnectFromAllDevices();
     appConfigApi.fetchLastTcpConnectionMeta();
 
     requestPorts();
@@ -205,7 +276,11 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
         </div>
 
         <div className="flex justify-center mt-5">
-          <Tabs.Root className="w-3/5" defaultValue={ConnectionType.SERIAL}>
+          <Tabs.Root
+            className="w-3/5"
+            defaultValue={defaultTabValue}
+            onValueChange={handleTabChange}
+          >
             <Tabs.List
               className="flex flex-row"
               aria-label="Choose a connection type"
@@ -248,6 +323,9 @@ export const ConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
                 setSocketPort={setSocketPort}
                 activeSocketState={activeSocketState}
                 handleSocketConnect={handleSocketConnect}
+                onRecentConnectionSelect={handleRecentConnectionSelect}
+                onRecentConnectionRemove={handleRecentConnectionRemove}
+                onCancelConnection={handleCancelConnection}
               />
             </Tabs.Content>
           </Tabs.Root>

--- a/src/features/appConfig/api.ts
+++ b/src/features/appConfig/api.ts
@@ -11,6 +11,7 @@ import {
   type IGeneralConfigState,
   type IMapConfigState,
   type TcpConnectionMeta,
+  type RecentConnection,
   appConfigSliceActions,
 } from "./slice";
 import { setColorModeClass } from "@utils/ui";
@@ -19,6 +20,9 @@ import { trackRequestOperation } from "@utils/api";
 export enum AppConfigApiActions {
   FetchLastTcpConnectionMeta = "appConfig/fetchLastTcpConnectionMeta",
   PersistLastTcpConnectionMeta = "appConfig/persistLastTcpConnectionMeta",
+  FetchRecentConnections = "appConfig/fetchRecentConnections",
+  PersistRecentConnections = "appConfig/persistRecentConnections",
+  AddRecentConnection = "appConfig/addRecentConnection",
   PersistGeneralConfig = "appConfig/persistGeneralConfig",
   PersistMapConfig = "appConfig/persistMapConfig",
   InitializeAppConfig = "appConfig/initializeAppConfig",
@@ -100,6 +104,43 @@ export const useAppConfigApi = () => {
     });
   };
 
+  const fetchRecentConnections = async () => {
+    const TYPE = AppConfigApiActions.FetchRecentConnections;
+
+    await trackRequestOperation(TYPE, dispatch, async () => {
+      const persistedValue = await getValueFromPersistedStore(
+        defaultStore,
+        PersistedStateKeys.RecentConnections,
+      );
+
+      dispatch(
+        appConfigSliceActions.setRecentConnections(persistedValue ?? []),
+      );
+    });
+  };
+
+  const persistRecentConnections = async (connections: RecentConnection[]) => {
+    const TYPE = AppConfigApiActions.PersistRecentConnections;
+
+    await trackRequestOperation(TYPE, dispatch, async () => {
+      await setAndValidateValueInPersistedStore(
+        defaultStore,
+        PersistedStateKeys.RecentConnections,
+        connections,
+        true,
+        "Failed to persist recent connections",
+      );
+    });
+  };
+
+  const addRecentConnection = async (connection: RecentConnection) => {
+    const TYPE = AppConfigApiActions.AddRecentConnection;
+
+    await trackRequestOperation(TYPE, dispatch, async () => {
+      dispatch(appConfigSliceActions.addRecentConnection(connection));
+    });
+  };
+
   const initializeAppConfig = async () => {
     const TYPE = AppConfigApiActions.InitializeAppConfig;
 
@@ -124,12 +165,17 @@ export const useAppConfigApi = () => {
       if (persistedMapConfig) {
         _updateMapConfig(persistedMapConfig);
       }
+
+      await fetchRecentConnections();
     });
   };
 
   return {
     fetchLastTcpConnectionMeta,
     persistLastTcpConnectionMeta,
+    fetchRecentConnections,
+    persistRecentConnections,
+    addRecentConnection,
     persistGeneralConfig,
     persistMapConfig,
     initializeAppConfig,

--- a/src/features/appConfig/selectors.ts
+++ b/src/features/appConfig/selectors.ts
@@ -3,6 +3,7 @@ import type {
   IGeneralConfigState,
   IMapConfigState,
   TcpConnectionMeta,
+  RecentConnection,
 } from "@features/appConfig/slice";
 
 export const selectPersistedTCPConnectionMeta =
@@ -19,3 +20,8 @@ export const selectMapConfigState =
   () =>
   (state: RootState): IMapConfigState =>
     state.appConfig.map;
+
+export const selectRecentConnections =
+  () =>
+  (state: RootState): RecentConnection[] =>
+    state.appConfig.recentConnections;

--- a/src/features/appConfig/slice.ts
+++ b/src/features/appConfig/slice.ts
@@ -5,6 +5,17 @@ export type TcpConnectionMeta = {
   port: number;
 };
 
+export type RecentConnection = {
+  id: string; // Unique identifier for the connection
+  address: string; // IP:port
+  lastConnected: number;
+  firstConnected: number;
+  // Device info (populated after successful connection)
+  deviceName?: string;
+  shortName?: string;
+  longName?: string;
+};
+
 export interface IMapConfigState {
   style: string;
 }
@@ -13,10 +24,12 @@ export type ColorMode = "light" | "dark" | "system";
 
 export interface IGeneralConfigState {
   colorMode: ColorMode;
+  selectedConnectionTab?: "SERIAL" | "TCP";
 }
 
 export interface IAppConfigState {
   lastTcpConnection: TcpConnectionMeta | null;
+  recentConnections: RecentConnection[];
   map: IMapConfigState;
   general: IGeneralConfigState;
   about: null;
@@ -26,12 +39,14 @@ export const initialAppConfigState: IAppConfigState = {
   // This is not intended to be manually updated by the user
   // Might be worth adding a new "hidden" object
   lastTcpConnection: null,
+  recentConnections: [],
 
   map: {
     style: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
   },
   general: {
     colorMode: "system",
+    selectedConnectionTab: "SERIAL",
   },
   about: null,
 };
@@ -45,6 +60,39 @@ export const appConfigSlice = createSlice({
       action: PayloadAction<TcpConnectionMeta | null>,
     ) => {
       state.lastTcpConnection = action.payload;
+    },
+    setRecentConnections: (
+      state,
+      action: PayloadAction<RecentConnection[]>,
+    ) => {
+      state.recentConnections = action.payload;
+    },
+    addRecentConnection: (state, action: PayloadAction<RecentConnection>) => {
+      const newConnection = action.payload;
+      const existingIndex = state.recentConnections.findIndex(
+        (conn) => conn.id === newConnection.id,
+      );
+
+      if (existingIndex >= 0) {
+        // Update existing connection and move to front
+        state.recentConnections[existingIndex] = newConnection;
+        const [updated] = state.recentConnections.splice(existingIndex, 1);
+        state.recentConnections.unshift(updated);
+      } else {
+        // Add new connection to front
+        state.recentConnections.unshift(newConnection);
+      }
+
+      // Keep only the 10 most recent connections
+      state.recentConnections = state.recentConnections.slice(0, 10);
+    },
+    removeRecentConnection: (
+      state,
+      action: PayloadAction<string>, // connection id
+    ) => {
+      state.recentConnections = state.recentConnections.filter(
+        (conn) => conn.id !== action.payload,
+      );
     },
     updateGeneralConfig: (
       state,

--- a/src/features/device/api.ts
+++ b/src/features/device/api.ts
@@ -155,9 +155,10 @@ export const useDeviceApi = () => {
         if (payload.setPrimary) {
           if (payload.params.type === ConnectionType.BLUETOOTH) {
             dispatch(
-              deviceSliceActions.setPrimaryDeviceConnectionKey(
-                payload.params.bluetoothName,
-              ),
+              deviceSliceActions.setPrimaryDeviceConnection({
+                key: payload.params.bluetoothName,
+                type: ConnectionType.BLUETOOTH,
+              }),
             );
           }
 

--- a/src/features/device/api.ts
+++ b/src/features/device/api.ts
@@ -119,17 +119,19 @@ export const useDeviceApi = () => {
         if (payload.setPrimary) {
           if (payload.params.type === ConnectionType.SERIAL) {
             dispatch(
-              deviceSliceActions.setPrimaryDeviceConnectionKey(
-                payload.params.portName,
-              ),
+              deviceSliceActions.setPrimaryDeviceConnection({
+                key: payload.params.portName,
+                type: ConnectionType.SERIAL,
+              }),
             );
           }
 
           if (payload.params.type === ConnectionType.TCP) {
             dispatch(
-              deviceSliceActions.setPrimaryDeviceConnectionKey(
-                payload.params.socketAddress,
-              ),
+              deviceSliceActions.setPrimaryDeviceConnection({
+                key: payload.params.socketAddress,
+                type: ConnectionType.TCP,
+              }),
             );
           }
         }
@@ -154,7 +156,7 @@ export const useDeviceApi = () => {
     await trackRequestOperation(TYPE, dispatch, async () => {
       await backendConnectionApi.dropDeviceConnection(payload);
 
-      dispatch(deviceSliceActions.setPrimaryDeviceConnectionKey(null));
+      dispatch(deviceSliceActions.setPrimaryDeviceConnection(null));
       dispatch(uiSliceActions.setActiveNode(null));
       dispatch(deviceSliceActions.setDevice(null));
     });
@@ -166,7 +168,7 @@ export const useDeviceApi = () => {
     await trackRequestOperation(TYPE, dispatch, async () => {
       await backendConnectionApi.dropAllDeviceConnections();
 
-      dispatch(deviceSliceActions.setPrimaryDeviceConnectionKey(null));
+      dispatch(deviceSliceActions.setPrimaryDeviceConnection(null));
       dispatch(uiSliceActions.setActiveNode(null));
       dispatch(deviceSliceActions.setDevice(null));
     });

--- a/src/features/device/selectors.ts
+++ b/src/features/device/selectors.ts
@@ -7,6 +7,7 @@ import type {
   app_device_NormalizedWaypoint,
   meshtastic_protobufs_User,
 } from "@bindings/index";
+import type { ConnectionType } from "@utils/connections";
 
 export const selectAvailablePorts =
   () =>
@@ -17,6 +18,11 @@ export const selectPrimaryDeviceKey =
   () =>
   (state: RootState): string | null =>
     state.devices.primaryDeviceKey;
+
+export const selectPrimaryConnectionType =
+  () =>
+  (state: RootState): ConnectionType | null =>
+    state.devices.primaryConnectionType;
 
 export const selectDevice =
   () =>

--- a/src/features/device/slice.ts
+++ b/src/features/device/slice.ts
@@ -1,11 +1,13 @@
 import { type PayloadAction, createSlice } from "@reduxjs/toolkit";
 
 import type { app_device_MeshDevice } from "@bindings/index";
+import type { ConnectionType } from "@utils/connections";
 
 export interface IDeviceState {
   device: app_device_MeshDevice | null;
   availableSerialPorts: string[] | null;
-  primaryDeviceKey: string | null; // port or socket ddress
+  primaryDeviceKey: string | null; // port or socket address
+  primaryConnectionType: ConnectionType | null; // connection type for primary device
   autoConnectPort: string | null; // Port to automatically connect to on startup
 }
 
@@ -13,6 +15,7 @@ export const initialDeviceState: IDeviceState = {
   device: null,
   availableSerialPorts: null,
   primaryDeviceKey: null,
+  primaryConnectionType: null,
   autoConnectPort: null,
 };
 
@@ -27,11 +30,20 @@ export const deviceSlice = createSlice({
       state.availableSerialPorts = action.payload;
     },
 
-    setPrimaryDeviceConnectionKey: (
+    setPrimaryDeviceConnection: (
       state,
-      action: PayloadAction<string | null>,
+      action: PayloadAction<{
+        key: string;
+        type: ConnectionType;
+      } | null>,
     ) => {
-      state.primaryDeviceKey = action.payload;
+      if (action.payload === null) {
+        state.primaryDeviceKey = null;
+        state.primaryConnectionType = null;
+      } else {
+        state.primaryDeviceKey = action.payload.key;
+        state.primaryConnectionType = action.payload.type;
+      }
     },
 
     setDevice: (state, action: PayloadAction<app_device_MeshDevice | null>) => {

--- a/src/hooks/useRecentConnectionTracker.ts
+++ b/src/hooks/useRecentConnectionTracker.ts
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from "react";
+import { useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
+
+import { useAppConfigApi } from "@features/appConfig/api";
+import {
+  selectDevice,
+  selectPrimaryDeviceKey,
+  selectPrimaryConnectionType,
+} from "@features/device/selectors";
+import { selectRecentConnections } from "@features/appConfig/selectors";
+import { appConfigSliceActions } from "@features/appConfig/slice";
+
+import {
+  createRecentConnectionFromDevice,
+  updateRecentConnectionWithDevice,
+} from "@utils/connections";
+
+/**
+ * Hook to track successful device connections and add them to recent connections
+ */
+export const useRecentConnectionTracker = () => {
+  const dispatch = useDispatch();
+  const appConfigApi = useAppConfigApi();
+
+  const device = useSelector(selectDevice());
+  const primaryDeviceKey = useSelector(selectPrimaryDeviceKey());
+  const connectionType = useSelector(selectPrimaryConnectionType());
+  const recentConnections = useSelector(selectRecentConnections());
+
+  // Track whether we've processed this specific device state to prevent infinite loops
+  const lastProcessedDeviceRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    // Only track when we have both device and primary connection
+    if (!device || !primaryDeviceKey || !connectionType) {
+      lastProcessedDeviceRef.current = null;
+      return;
+    }
+
+    // Only track TCP connections
+    if (connectionType !== "TCP") {
+      return;
+    }
+
+    const connectedNodeId = device.myNodeInfo?.myNodeNum;
+    const connectedUser = connectedNodeId
+      ? device.nodes?.[connectedNodeId]?.user
+      : null;
+
+    // Skip if we don't have basic device info yet
+    if (!device.myNodeInfo || !connectedNodeId) {
+      return;
+    }
+
+    try {
+      // Create a unique key based on device data that matters for recent connections
+      const deviceKey = JSON.stringify({
+        primaryDeviceKey,
+        myNodeNum: connectedNodeId,
+        connectedUser,
+      });
+
+      // Prevent processing the exact same device state multiple times
+      if (lastProcessedDeviceRef.current === deviceKey) {
+        return;
+      }
+
+      const address = primaryDeviceKey;
+      const connectionId = `TCP:${address}`;
+      const existingConnection = recentConnections.find(
+        (conn) => conn.id === connectionId,
+      );
+
+      if (existingConnection) {
+        // Update metadata of existing recent connections
+        const updatedConnection = updateRecentConnectionWithDevice(
+          existingConnection,
+          device,
+        );
+
+        dispatch(appConfigSliceActions.addRecentConnection(updatedConnection));
+
+        const currentConnections = recentConnections.filter(
+          (conn) => conn.id !== connectionId,
+        );
+        appConfigApi.persistRecentConnections([
+          updatedConnection,
+          ...currentConnections,
+        ]);
+      } else {
+        // Add to recent connections
+        const newConnection = createRecentConnectionFromDevice(address, device);
+        dispatch(appConfigSliceActions.addRecentConnection(newConnection));
+
+        const updatedConnections = [newConnection, ...recentConnections].slice(
+          0,
+          10,
+        );
+        appConfigApi.persistRecentConnections(updatedConnections);
+      }
+
+      lastProcessedDeviceRef.current = deviceKey;
+    } catch (error) {
+      console.warn("Failed to track recent connection:", error);
+      lastProcessedDeviceRef.current = null;
+    }
+  }, [
+    device,
+    primaryDeviceKey,
+    connectionType,
+    dispatch,
+    appConfigApi,
+    recentConnections,
+  ]);
+};

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -6,7 +6,9 @@
     "notApplicable": "N/A",
     "goHome": "Go home",
     "unknown": "UNK",
-    "wip": "Unimplemented, work in progress"
+    "wip": "Unimplemented, work in progress",
+    "connected": "Connected",
+    "disconnect": "Disconnect"
   },
   "splashPage": {
     "photoAttribution": "Photo by <link1>Caleb Riston</link1> on <link2>Unsplash</link2>"
@@ -36,6 +38,18 @@
         "connecting": "Connecting..."
       }
     }
+  },
+  "recentConnections": {
+    "title": "Recent Connections",
+    "subtitle": "Select from your recently used connections",
+    "noRecent": "No recent connections found",
+    "justNow": "Just now",
+    "minutesAgo_one": "{{count}} minute ago",
+    "minutesAgo_other": "{{count}} minutes ago",
+    "hoursAgo_one": "{{count}} hour ago",
+    "hoursAgo_other": "{{count}} hours ago",
+    "daysAgo_one": "{{count}} day ago",
+    "daysAgo_other": "{{count}} days ago"
   },
   "sidebar": {
     "overviewGroup": "Overview",

--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -1,6 +1,56 @@
+import type { RecentConnection } from "@features/appConfig/slice";
+import type { app_device_MeshDevice } from "@bindings/index";
+
 export type DeviceKey = string;
 
 export enum ConnectionType {
   SERIAL = "SERIAL",
   TCP = "TCP",
+}
+
+export function createRecentConnectionFromDevice(
+  address: string,
+  device?: app_device_MeshDevice | null,
+): RecentConnection {
+  const id = `TCP:${address}`;
+
+  const connectedNodeId = device?.myNodeInfo.myNodeNum;
+  const connectedNode = connectedNodeId ? device?.nodes[connectedNodeId] : null;
+  const user = connectedNode?.user;
+
+  const deviceName = user?.longName || user?.shortName || "Unknown Device";
+
+  return {
+    id,
+    address,
+    deviceName,
+    shortName: user?.shortName,
+    longName: user?.longName,
+    lastConnected: Date.now(),
+    firstConnected: Date.now(),
+  };
+}
+
+export function updateRecentConnectionWithDevice(
+  connection: RecentConnection,
+  device?: app_device_MeshDevice | null,
+): RecentConnection {
+  // Get device name from connected device
+  const connectedNodeId = device?.myNodeInfo.myNodeNum;
+  const connectedNode = connectedNodeId ? device?.nodes[connectedNodeId] : null;
+  const user = connectedNode?.user;
+
+  const deviceName =
+    user?.longName ||
+    user?.shortName ||
+    connection.deviceName ||
+    "Unknown Device";
+
+  return {
+    ...connection,
+    deviceName,
+    shortName: user?.shortName || connection.shortName,
+    longName: user?.longName || connection.longName,
+    lastConnected: Date.now(),
+  };
 }

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -2,6 +2,7 @@ import type {
   IGeneralConfigState,
   IMapConfigState,
   TcpConnectionMeta,
+  RecentConnection,
 } from "@features/appConfig/slice";
 import type { Store } from "@tauri-apps/plugin-store";
 
@@ -9,12 +10,14 @@ export const DEFAULT_STORE_FILE_NAME = "config.bin";
 
 export enum PersistedStateKeys {
   LastTcpConnection = "lastTcpConnection",
+  RecentConnections = "recentConnections",
   GeneralConfig = "generalConfig",
   MapConfig = "mapConfig",
 }
 
 export interface IPersistedState {
   [PersistedStateKeys.LastTcpConnection]?: TcpConnectionMeta;
+  [PersistedStateKeys.RecentConnections]?: RecentConnection[];
   [PersistedStateKeys.GeneralConfig]?: IGeneralConfigState;
   [PersistedStateKeys.MapConfig]?: IMapConfigState;
 }


### PR DESCRIPTION
## Background

I recently discovered this project, and am super excited to use (and contributing to) it extensively. The first issue I ran into is that it is a bit of a pain to switch between my nodes, and I kept forgetting which node I was connected to. So, this PR adds a connection status card, a disconnect button, and a list of recent connections. These features allows me to quickly switch between my nodes, and helps me not forget which one I'm connected to.

## Changes

- Add connection status - shows the current connection
- Add disconnect button - allows connecting to another node without exiting the app
- Add recent TCP connections list - allows quickly switching between recent nodes
- Add current connection page tab to state - avoids needing to click TCP tab every time I want to switch between nodes
- Add "connecting..." overlay
  - Fixes small visual glitch where the "Connecting..." button would briefly go back to "Connect" before the page changes
  - Fixes similar visual glitch of recent connections appearing in the list while connecting
  - Allows cancelling connection if it takes too long

## Screenshots


When there are no recent connections (when user upgrades to this version) the UI appears unchanged
<img width="1307" height="953" alt="Screenshot 2025-09-10 at 2 05 15 PM" src="https://github.com/user-attachments/assets/16641b8b-c9fc-4e95-8608-7d64b3d1b1a8" />


Once you connect you'll see a connection status card with a disconnect button
<img width="1434" height="1269" alt="Screenshot 2025-09-11 at 10 51 11 AM" src="https://github.com/user-attachments/assets/9c797cbe-068b-4a49-a9b4-81b3d021935a" />

Disconnect button with sidebar collapsed
<img width="831" height="1268" alt="Screenshot 2025-09-11 at 10 51 18 AM" src="https://github.com/user-attachments/assets/ef4537ad-2a35-496d-b443-fb2cc0ddf0dd" />


Connection status (serial connection)
<img width="321" height="216" alt="Screenshot 2025-09-11 at 11 01 49 AM" src="https://github.com/user-attachments/assets/9ab1c021-be14-4674-8203-59bc366387d0" />

Connection status (bluetooth)
<img width="633" height="447" alt="Screenshot 2025-09-11 at 10 50 50 AM" src="https://github.com/user-attachments/assets/4690c3be-4a82-4bde-a2a3-5e25d3afe3ec" />


Recent connections are shown in a list below the existing TCP connection form
<img width="550" height="1013" alt="Screenshot 2025-09-10 at 2 05 57 PM" src="https://github.com/user-attachments/assets/d16ca42c-d064-47a8-9db0-8c2fea37bb91" />


New connecting screen with cancel button
<img width="695" height="675" alt="Screenshot 2025-09-10 at 2 19 38 PM" src="https://github.com/user-attachments/assets/e5bdd3b7-d06d-455b-9c07-6d81178efaab" />
